### PR TITLE
Add import tasks for exits and receptions

### DIFF
--- a/app/models/doc/historical_sentence.rb
+++ b/app/models/doc/historical_sentence.rb
@@ -1,0 +1,2 @@
+class Doc::HistoricalSentence < ApplicationRecord
+end

--- a/app/models/party.rb
+++ b/app/models/party.rb
@@ -1,6 +1,7 @@
 class Party < ApplicationRecord
   belongs_to :party_type
   belongs_to :parent_party, optional: true
+  belongs_to :doc_profile, optional: true
   has_many :case_parties, dependent: :destroy
   has_many :court_cases, through: :case_parties
   has_many :counsel_parties, dependent: :destroy
@@ -18,4 +19,8 @@ class Party < ApplicationRecord
   scope :with_parent, -> { where.not(parent_party_id: nil) }
   scope :arresting_agency, -> { joins(:party_type).where(party_types: { name: 'arresting_agency' }) }
   scope :defendant, -> { joins(:party_type).where(party_types: { name: 'defendant' }) }
+
+  def last_first
+    "#{last_name} #{first_name}"
+  end
 end

--- a/app/services/importers/doc/link_cases.rb
+++ b/app/services/importers/doc/link_cases.rb
@@ -14,6 +14,10 @@ module Importers
         sentences.each do |sentence|
           bar.increment!
           cc = match_regex(sentence)
+          # TODO: Check for party matches
+          # TODO: Best: match threshold 0.8 (Dice) + birth month / year match
+          # TODO: Good: match threshold 0.6 + birth month / year match
+          # TODO: Bad (Don't): match threshold < 0.6 || birth month / year match
           sentence.update(court_case_id: cc) if cc.present?
         end
       end

--- a/app/services/importers/doc/link_parties.rb
+++ b/app/services/importers/doc/link_parties.rb
@@ -1,0 +1,37 @@
+module Importers
+  module Doc
+    class LinkParties
+      attr_accessor :sentences, :bar
+
+      def initialize
+        @sentences = ::Doc::Sentence.where(sentencing_county: 'OKLAHOMA COUNTY COURT').where.not(court_case_id: nil)
+        @bar = ProgressBar.new(@sentences.count)
+      end
+
+      def perform
+        puts "Processing #{@sentences.count} sentences"
+        results = { success: 0, failed: 0 }
+
+        sentences.each do |sentence|
+          bar.increment!
+          next if sentence.court_case_id.nil?
+
+          parties = sentence.court_case.parties.defendant
+
+          next if parties.size.zero?
+
+          fz = FuzzyMatch.new(parties, read: :last_first)
+          match = fz.find("#{sentence.profile.last_name} #{sentence.profile.first_name}", threshold: 0.8)
+
+          if match.present?
+            match.update(doc_profile_id: sentence.doc_profile_id) if match.doc_profile_id.nil?
+            results[:success] += 1
+          else
+            binding.pry
+          end
+        end
+        puts results
+      end
+    end
+  end
+end

--- a/app/services/importers/doc/old_exits.rb
+++ b/app/services/importers/doc/old_exits.rb
@@ -20,8 +20,8 @@ module Importers
           begin
             ::Doc::Status.find_or_create_by(
               doc_profile_id: id,
-              facility: row['ExitReason'],
-              reason: row[3],
+              facility: row['ExitReason']&.squish,
+              reason: row[3]&.squish,
               date: parse_date(row['ExitDate'])
             )
 

--- a/app/services/importers/doc/old_exits.rb
+++ b/app/services/importers/doc/old_exits.rb
@@ -1,0 +1,40 @@
+module Importers
+  module Doc
+    class OldExits
+      attr_accessor :file, :doc_mapping
+
+      def initialize
+        @file = CSV.parse(File.open('lib/data/2017/OffenderExit.csv'), headers: true)
+        @doc_mapping = ::Doc::Profile.pluck(:doc_number, :id).to_h
+      end
+
+      def perform
+        bar = ProgressBar.new(file.count)
+
+        success = { success: 0, failure: 0 }
+        file.each do |row|
+          bar.increment!
+          id = doc_mapping[row['DOCNum'].to_i]
+          next unless id.present?
+
+          begin
+            ::Doc::Status.find_or_create_by(
+              doc_profile_id: id,
+              facility: row['ExitReason'],
+              reason: row[3],
+              date: parse_date(row['ExitDate'])
+            )
+
+            success[:success] += 1
+          rescue StandardError => e
+            success[:failure] += 1
+          end
+        end
+      end
+
+      def parse_date(date_string)
+        Date.parse(date_string)
+      end
+    end
+  end
+end

--- a/app/services/importers/doc/old_receptions.rb
+++ b/app/services/importers/doc/old_receptions.rb
@@ -20,8 +20,8 @@ module Importers
           begin
             ::Doc::Status.find_or_create_by!(
               doc_profile_id: id,
-              facility: row['Facility'],
-              reason: row['Reason'],
+              facility: row['Facility']&.squish,
+              reason: row['Reason']&.squish,
               date: parse_date(row['MovementDate'])
             )
             success[:success] += 1

--- a/app/services/importers/doc/old_receptions.rb
+++ b/app/services/importers/doc/old_receptions.rb
@@ -1,0 +1,39 @@
+module Importers
+  module Doc
+    class OldReceptions
+      attr_accessor :file, :doc_mapping
+
+      def initialize
+        @file = CSV.parse(File.open('lib/data/2017/OffenderReception.csv'), headers: true)
+        @doc_mapping = ::Doc::Profile.pluck(:doc_number, :id).to_h
+      end
+
+      def perform
+        bar = ProgressBar.new(file.count)
+
+        success = { success: 0, failure: 0 }
+        file.each do |row|
+          bar.increment!
+          id = doc_mapping[row['DocNum'].to_i]
+          next unless id.present?
+
+          begin
+            ::Doc::Status.find_or_create_by!(
+              doc_profile_id: id,
+              facility: row['Facility'],
+              reason: row['Reason'],
+              date: parse_date(row['MovementDate'])
+            )
+            success[:success] += 1
+          rescue StandardError => e
+            success[:failure] += 1
+          end
+        end
+      end
+
+      def parse_date(date_string)
+        Date.parse(date_string)
+      end
+    end
+  end
+end

--- a/app/services/importers/doc/old_sentences.rb
+++ b/app/services/importers/doc/old_sentences.rb
@@ -1,0 +1,28 @@
+module Importers
+  module Doc
+    class OldSentences
+      attr_accessor :file, :doc_mapping, :sentences_mapping
+
+      def initialize
+        @file = CSV.parse(File.open('lib/data/2017/OffenderSentence.csv'), headers: true, liberal_parsing: true)
+        @doc_mapping = ::Doc::Profile.pluck(:doc_number, :id).to_h
+        @sentences_mapping = ::Doc::Sentence.pluck(:sentence_id, :id).to_h
+      end
+
+      def perform
+        bar = ProgressBar.new(file.count)
+
+        file.each do |row|
+          bar.increment!
+          id = doc_mapping[row['DOCNum'].to_i]
+          binding.pry
+          next unless id.present?
+        end
+      end
+
+      def parse_date(date_string)
+        Date.parse(date_string)
+      end
+    end
+  end
+end

--- a/app/services/importers/doc/old_sentences.rb
+++ b/app/services/importers/doc/old_sentences.rb
@@ -4,19 +4,45 @@ module Importers
       attr_accessor :file, :doc_mapping, :sentences_mapping
 
       def initialize
-        @file = CSV.parse(File.open('lib/data/2017/OffenderSentence.csv'), headers: true, liberal_parsing: true)
         @doc_mapping = ::Doc::Profile.pluck(:doc_number, :id).to_h
         @sentences_mapping = ::Doc::Sentence.pluck(:sentence_id, :id).to_h
       end
 
       def perform
-        bar = ProgressBar.new(file.count)
+        bar = ProgressBar.new(1_275_000)
+        skipped = []
 
-        file.each do |row|
+        CSV.foreach(File.open('lib/data/2017/OffenderSentence.csv'), headers: true, liberal_parsing: true) do |row|
           bar.increment!
-          id = doc_mapping[row['DOCNum'].to_i]
-          binding.pry
-          next unless id.present?
+
+          if doc_mapping[row['DOCNum'].to_i].nil?
+            skipped << row['DOCNum'].to_i
+            next
+          else
+            ::Doc::HistoricalSentence.find_or_create_by!(
+              external_id: row['Id'],
+              doc_profile_id: doc_mapping[row['DOCNum'].to_i],
+              order_id: row['OrderID'],
+              charge_seq: row['ChargeSeq'],
+              crf_num: row['CRFNum'],
+              convict_date: row['ConvictDate'],
+              court: row['Court'],
+              statute_code: row['StatuteCode'],
+              offence_description: row['OffenceDescription'],
+              offence_comment: row['OffenceComment'],
+              sentence_term_code: row['SentenceTermCode'],
+              years: row['Years'],
+              months: row['Months'],
+              days: row['Days'],
+              sentence_term: row['SentenceTerm'],
+              start_date: row['StartDate'],
+              end_date: row['EndDate'],
+              count_num: row['CountNum'],
+              order_code: row['OrderCode'],
+              consecutive_to_count: row['ConsecutiveToCount'],
+              charge_status: row['ChargeStatus']
+            )
+          end
         end
       end
 

--- a/db/migrate/20220412135855_create_doc_historical_sentences.rb
+++ b/db/migrate/20220412135855_create_doc_historical_sentences.rb
@@ -1,0 +1,29 @@
+class CreateDocHistoricalSentences < ActiveRecord::Migration[6.0]
+  def change
+    create_table :doc_historical_sentences do |t|
+      t.integer :external_id
+      t.references :doc_profile
+      t.string :order_id
+      t.string :charge_seq
+      t.string :crf_num
+      t.date :convict_date
+      t.string :court
+      t.string :statute_code
+      t.string :offence_description
+      t.string :offence_comment
+      t.string :sentence_term_code
+      t.string :years
+      t.string :months
+      t.string :days
+      t.string :sentence_term
+      t.date :start_date
+      t.date :end_date
+      t.string :count_num
+      t.string :order_code
+      t.string :consecutive_to_count
+      t.string :charge_status
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220412200059_add_doc_profile_id_to_parties.rb
+++ b/db/migrate/20220412200059_add_doc_profile_id_to_parties.rb
@@ -1,0 +1,5 @@
+class AddDocProfileIdToParties < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :parties, :doc_profile, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_12_135855) do
+ActiveRecord::Schema.define(version: 2022_04_12_200059) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -310,6 +310,8 @@ ActiveRecord::Schema.define(version: 2022_04_12_135855) do
     t.integer "birth_year"
     t.string "suffix"
     t.bigint "parent_party_id"
+    t.bigint "doc_profile_id"
+    t.index ["doc_profile_id"], name: "index_parties_on_doc_profile_id"
     t.index ["oscn_id"], name: "index_parties_on_oscn_id", unique: true
     t.index ["parent_party_id"], name: "index_parties_on_parent_party_id"
     t.index ["party_type_id"], name: "index_parties_on_party_type_id"
@@ -393,6 +395,7 @@ ActiveRecord::Schema.define(version: 2022_04_12_135855) do
   add_foreign_key "events", "court_cases"
   add_foreign_key "events", "parties"
   add_foreign_key "judges", "counties"
+  add_foreign_key "parties", "doc_profiles"
   add_foreign_key "parties", "parent_parties"
   add_foreign_key "parties", "party_types"
   add_foreign_key "party_addresses", "parties"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_09_155913) do
+ActiveRecord::Schema.define(version: 2022_04_12_135855) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -138,6 +138,33 @@ ActiveRecord::Schema.define(version: 2022_03_09_155913) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["doc_profile_id"], name: "index_doc_aliases_on_doc_profile_id"
+  end
+
+  create_table "doc_historical_sentences", force: :cascade do |t|
+    t.integer "external_id"
+    t.bigint "doc_profile_id"
+    t.string "order_id"
+    t.string "charge_seq"
+    t.string "crf_num"
+    t.date "convict_date"
+    t.string "court"
+    t.string "statute_code"
+    t.string "offence_description"
+    t.string "offence_comment"
+    t.string "sentence_term_code"
+    t.string "years"
+    t.string "months"
+    t.string "days"
+    t.string "sentence_term"
+    t.date "start_date"
+    t.date "end_date"
+    t.string "count_num"
+    t.string "order_code"
+    t.string "consecutive_to_count"
+    t.string "charge_status"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["doc_profile_id"], name: "index_doc_historical_sentences_on_doc_profile_id"
   end
 
   create_table "doc_offense_codes", force: :cascade do |t|
@@ -428,7 +455,7 @@ ActiveRecord::Schema.define(version: 2022_03_09_155913) do
       ( SELECT count(*) AS count
              FROM (docket_events
                JOIN docket_event_types ON ((docket_events.docket_event_type_id = docket_event_types.id)))
-            WHERE ((docket_events.party_id = parties.id) AND ((docket_event_types.code)::text = ANY ((ARRAY['WAI$'::character varying, 'BWIFAP'::character varying, 'BWIFA'::character varying, 'BWIFC'::character varying, 'BWIAR'::character varying, 'BWIAA'::character varying, 'BWICA'::character varying, 'BWIFAR'::character varying, 'BWIFAA'::character varying, 'BWIFP'::character varying, 'BWIMW'::character varying, 'BWIR8'::character varying, 'BWIS'::character varying, 'BWIS$'::character varying, 'WAI'::character varying, 'WAIMV'::character varying, 'WAIMW'::character varying, 'BWIFAR'::character varying])::text[])))) AS warrants_count,
+            WHERE ((docket_events.party_id = parties.id) AND ((docket_event_types.code)::text = ANY (ARRAY[('WAI$'::character varying)::text, ('BWIFAP'::character varying)::text, ('BWIFA'::character varying)::text, ('BWIFC'::character varying)::text, ('BWIAR'::character varying)::text, ('BWIAA'::character varying)::text, ('BWICA'::character varying)::text, ('BWIFAR'::character varying)::text, ('BWIFAA'::character varying)::text, ('BWIFP'::character varying)::text, ('BWIMW'::character varying)::text, ('BWIR8'::character varying)::text, ('BWIS'::character varying)::text, ('BWIS$'::character varying)::text, ('WAI'::character varying)::text, ('WAIMV'::character varying)::text, ('WAIMW'::character varying)::text, ('BWIFAR'::character varying)::text])))) AS warrants_count,
       ( SELECT sum(docket_events.amount) AS sum
              FROM docket_events
             WHERE (docket_events.party_id = parties.id)) AS total_fined,
@@ -505,7 +532,7 @@ ActiveRecord::Schema.define(version: 2022_03_09_155913) do
               ELSE NULL::text
           END AS shortdescription,
           CASE
-              WHEN ((docket_event_types.code)::text = ANY ((ARRAY['BWIFA'::character varying, 'BWIFAA'::character varying, 'BWIFAR'::character varying])::text[])) THEN true
+              WHEN ((docket_event_types.code)::text = ANY (ARRAY[('BWIFA'::character varying)::text, ('BWIFAA'::character varying)::text, ('BWIFAR'::character varying)::text])) THEN true
               ELSE false
           END AS is_failure_to_appear,
           CASE
@@ -521,11 +548,11 @@ ActiveRecord::Schema.define(version: 2022_03_09_155913) do
               ELSE false
           END AS is_failure_to_comply,
           CASE
-              WHEN ((docket_event_types.code)::text = ANY ((ARRAY['BWIFAP'::character varying, 'BWIFA'::character varying, 'BWIFC'::character varying, 'BWIAA'::character varying, 'BWIAR'::character varying, 'BWICA'::character varying, 'BWIFAR'::character varying, 'BWIFAA'::character varying, 'BWIR8'::character varying, 'BWIS'::character varying, 'BWIS$'::character varying, 'BWIFP'::character varying, 'BWIMW'::character varying])::text[])) THEN true
+              WHEN ((docket_event_types.code)::text = ANY (ARRAY[('BWIFAP'::character varying)::text, ('BWIFA'::character varying)::text, ('BWIFC'::character varying)::text, ('BWIAA'::character varying)::text, ('BWIAR'::character varying)::text, ('BWICA'::character varying)::text, ('BWIFAR'::character varying)::text, ('BWIFAA'::character varying)::text, ('BWIR8'::character varying)::text, ('BWIS'::character varying)::text, ('BWIS$'::character varying)::text, ('BWIFP'::character varying)::text, ('BWIMW'::character varying)::text])) THEN true
               ELSE false
           END AS is_bench_warrant_issued,
           CASE
-              WHEN ((docket_event_types.code)::text = ANY ((ARRAY['WAI'::character varying, 'WAI$'::character varying])::text[])) THEN true
+              WHEN ((docket_event_types.code)::text = ANY (ARRAY[('WAI'::character varying)::text, ('WAI$'::character varying)::text])) THEN true
               ELSE false
           END AS is_arrest_warrant_issued,
           CASE
@@ -541,7 +568,7 @@ ActiveRecord::Schema.define(version: 2022_03_09_155913) do
               ELSE false
           END AS is_cause,
           CASE
-              WHEN ((docket_event_types.code)::text = ANY ((ARRAY['BWIMW'::character varying, 'WAIMW'::character varying])::text[])) THEN true
+              WHEN ((docket_event_types.code)::text = ANY (ARRAY[('BWIMW'::character varying)::text, ('WAIMW'::character varying)::text])) THEN true
               ELSE false
           END AS is_material_witness,
           CASE
@@ -553,7 +580,7 @@ ActiveRecord::Schema.define(version: 2022_03_09_155913) do
               ELSE false
           END AS is_material_rule_8,
           CASE
-              WHEN ((docket_event_types.code)::text = ANY ((ARRAY['BWIS$'::character varying, 'BWIS'::character varying])::text[])) THEN true
+              WHEN ((docket_event_types.code)::text = ANY (ARRAY[('BWIS$'::character varying)::text, ('BWIS'::character varying)::text])) THEN true
               ELSE false
           END AS is_service_by_sheriff,
           CASE
@@ -572,7 +599,7 @@ ActiveRecord::Schema.define(version: 2022_03_09_155913) do
        JOIN docket_event_types ON ((docket_event_types.id = docket_events.docket_event_type_id)))
        JOIN court_cases ON ((court_cases.id = docket_events.court_case_id)))
        JOIN case_types ON ((court_cases.case_type_id = case_types.id)))
-    WHERE ((docket_event_types.code)::text = ANY ((ARRAY['WAI$'::character varying, 'BWIFAP'::character varying, 'BWIFA'::character varying, 'BWIAR'::character varying, 'BWIAA'::character varying, 'BWIFC'::character varying, 'BWIFAR'::character varying, 'BWICA'::character varying, 'BWIFAA'::character varying, 'BWIFP'::character varying, 'BWIMW'::character varying, 'BWIR8'::character varying, 'BWIS'::character varying, 'BWIS$'::character varying, 'WAI'::character varying, 'WAIMV'::character varying, 'WAIMW'::character varying, 'RETBW'::character varying, 'RETWA'::character varying])::text[]));
+    WHERE ((docket_event_types.code)::text = ANY (ARRAY[('WAI$'::character varying)::text, ('BWIFAP'::character varying)::text, ('BWIFA'::character varying)::text, ('BWIAR'::character varying)::text, ('BWIAA'::character varying)::text, ('BWIFC'::character varying)::text, ('BWIFAR'::character varying)::text, ('BWICA'::character varying)::text, ('BWIFAA'::character varying)::text, ('BWIFP'::character varying)::text, ('BWIMW'::character varying)::text, ('BWIR8'::character varying)::text, ('BWIS'::character varying)::text, ('BWIS$'::character varying)::text, ('WAI'::character varying)::text, ('WAIMV'::character varying)::text, ('WAIMW'::character varying)::text, ('RETBW'::character varying)::text, ('RETWA'::character varying)::text]));
   SQL
   add_index "report_warrants", ["party_id", "code"], name: "index_report_warrants_on_party_id_and_code"
 
@@ -587,7 +614,7 @@ ActiveRecord::Schema.define(version: 2022_03_09_155913) do
           CASE
               WHEN (( SELECT count(*) AS count
                  FROM report_warrants
-                WHERE ((parties.id = report_warrants.party_id) AND ((report_warrants.code)::text = ANY ((ARRAY['WAI$'::character varying, 'BWIFAP'::character varying, 'BWIFA'::character varying, 'BWIFC'::character varying, 'BWIAR'::character varying, 'BWIAA'::character varying, 'BWICA'::character varying, 'BWIFAR'::character varying, 'BWIFAA'::character varying, 'BWIFP'::character varying, 'BWIMW'::character varying, 'BWIR8'::character varying, 'BWIS'::character varying, 'BWIS$'::character varying, 'WAI'::character varying, 'WAIMV'::character varying, 'WAIMW'::character varying, 'BWIFAR'::character varying])::text[])))) > ( SELECT count(*) AS count
+                WHERE ((parties.id = report_warrants.party_id) AND ((report_warrants.code)::text = ANY (ARRAY[('WAI$'::character varying)::text, ('BWIFAP'::character varying)::text, ('BWIFA'::character varying)::text, ('BWIFC'::character varying)::text, ('BWIAR'::character varying)::text, ('BWIAA'::character varying)::text, ('BWICA'::character varying)::text, ('BWIFAR'::character varying)::text, ('BWIFAA'::character varying)::text, ('BWIFP'::character varying)::text, ('BWIMW'::character varying)::text, ('BWIR8'::character varying)::text, ('BWIS'::character varying)::text, ('BWIS$'::character varying)::text, ('WAI'::character varying)::text, ('WAIMV'::character varying)::text, ('WAIMW'::character varying)::text, ('BWIFAR'::character varying)::text])))) > ( SELECT count(*) AS count
                  FROM report_warrants
                 WHERE ((parties.id = report_warrants.party_id) AND ((report_warrants.code)::text = 'RETWA'::text)))) THEN 'Yes'::text
               ELSE 'No'::text
@@ -599,7 +626,7 @@ ActiveRecord::Schema.define(version: 2022_03_09_155913) do
               WHEN (( SELECT count(*) AS count
                  FROM (docket_events
                    JOIN docket_event_types ON ((docket_events.docket_event_type_id = docket_event_types.id)))
-                WHERE ((docket_events.court_case_id = court_cases.id) AND ((docket_event_types.code)::text = ANY ((ARRAY['WAI$'::character varying, 'BWIFAP'::character varying, 'BWIFA'::character varying, 'BWIFC'::character varying, 'BWIAR'::character varying, 'BWIAA'::character varying, 'BWICA'::character varying, 'BWIFAR'::character varying, 'BWIFAA'::character varying, 'BWIFP'::character varying, 'BWIMW'::character varying, 'BWIR8'::character varying, 'BWIS'::character varying, 'BWIS$'::character varying, 'WAI'::character varying, 'WAIMV'::character varying, 'WAIMW'::character varying, 'BWIFAR'::character varying])::text[])))) > 0) THEN 'Yes'::text
+                WHERE ((docket_events.court_case_id = court_cases.id) AND ((docket_event_types.code)::text = ANY (ARRAY[('WAI$'::character varying)::text, ('BWIFAP'::character varying)::text, ('BWIFA'::character varying)::text, ('BWIFC'::character varying)::text, ('BWIAR'::character varying)::text, ('BWIAA'::character varying)::text, ('BWICA'::character varying)::text, ('BWIFAR'::character varying)::text, ('BWIFAA'::character varying)::text, ('BWIFP'::character varying)::text, ('BWIMW'::character varying)::text, ('BWIR8'::character varying)::text, ('BWIS'::character varying)::text, ('BWIS$'::character varying)::text, ('WAI'::character varying)::text, ('WAIMV'::character varying)::text, ('WAIMW'::character varying)::text, ('BWIFAR'::character varying)::text])))) > 0) THEN 'Yes'::text
               ELSE 'No'::text
           END AS warrant_on_case,
       pleas.name AS plea,
@@ -637,7 +664,7 @@ ActiveRecord::Schema.define(version: 2022_03_09_155913) do
       ( SELECT count(*) AS count
              FROM (docket_events
                JOIN docket_event_types ON ((docket_events.docket_event_type_id = docket_event_types.id)))
-            WHERE ((docket_events.court_case_id = court_cases.id) AND ((docket_event_types.code)::text = ANY ((ARRAY['WAI$'::character varying, 'BWIFAP'::character varying, 'BWIFA'::character varying, 'BWIFC'::character varying, 'BWIAR'::character varying, 'BWIAA'::character varying, 'BWICA'::character varying, 'BWIFAR'::character varying, 'BWIFAA'::character varying, 'BWIFP'::character varying, 'BWIMW'::character varying, 'BWIR8'::character varying, 'BWIS'::character varying, 'BWIS$'::character varying, 'WAI'::character varying, 'WAIMV'::character varying, 'WAIMW'::character varying, 'BWIFAR'::character varying])::text[])))) AS warrants_count
+            WHERE ((docket_events.court_case_id = court_cases.id) AND ((docket_event_types.code)::text = ANY (ARRAY[('WAI$'::character varying)::text, ('BWIFAP'::character varying)::text, ('BWIFA'::character varying)::text, ('BWIFC'::character varying)::text, ('BWIAR'::character varying)::text, ('BWIAA'::character varying)::text, ('BWICA'::character varying)::text, ('BWIFAR'::character varying)::text, ('BWIFAA'::character varying)::text, ('BWIFP'::character varying)::text, ('BWIMW'::character varying)::text, ('BWIR8'::character varying)::text, ('BWIS'::character varying)::text, ('BWIS$'::character varying)::text, ('WAI'::character varying)::text, ('WAIMV'::character varying)::text, ('WAIMW'::character varying)::text, ('BWIFAR'::character varying)::text])))) AS warrants_count
      FROM court_cases;
   SQL
   add_index "case_stats", ["court_case_id"], name: "index_case_stats_on_court_case_id"

--- a/lib/tasks/doc.rake
+++ b/lib/tasks/doc.rake
@@ -23,6 +23,10 @@ namespace :doc do
     Importers::Doc::OldExits.new.perform
   end
 
+  task old_sentences: [:environment] do
+    Importers::Doc::OldSentences.new.perform
+  end
+
   desc 'Import profiles'
   task profiles: [:environment] do
     Importers::Doc::Profile.new('2022-01').perform

--- a/lib/tasks/doc.rake
+++ b/lib/tasks/doc.rake
@@ -59,6 +59,11 @@ namespace :doc do
     Importers::Doc::LinkCases.new(county).perform
   end
 
+  desc 'Link OSCN parties to DOC profile'
+  task link_parties: [:environment] do
+    Importers::Doc::LinkParties.new.perform
+  end
+
   desc 'Link Sentence to OffenseCode'
   task link_offense_codes: [:environment] do
     Importers::Doc::LinkOffenseCodes.new.perform

--- a/lib/tasks/doc.rake
+++ b/lib/tasks/doc.rake
@@ -15,6 +15,14 @@ namespace :doc do
     Importers::Doc::Alias.new('2022-01').perform
   end
 
+  task old_receptions: [:environment] do
+    Importers::Doc::OldReceptions.new.perform
+  end
+
+  task old_exits: [:environment] do
+    Importers::Doc::OldExits.new.perform
+  end
+
   desc 'Import profiles'
   task profiles: [:environment] do
     Importers::Doc::Profile.new('2022-01').perform

--- a/spec/factories/doc/historical_sentences.rb
+++ b/spec/factories/doc/historical_sentences.rb
@@ -1,0 +1,25 @@
+FactoryBot.define do
+  factory :doc_historical_sentence, class: 'Doc::HistoricalSentence' do
+    external_id { 1 }
+    doc_profile { "" }
+    order_id { "MyString" }
+    charge_seq { "MyString" }
+    crf_num { "MyString" }
+    convict_date { "2022-04-12" }
+    court { "MyString" }
+    statute_code { "MyString" }
+    offence_description { "MyString" }
+    offence_comment { "MyString" }
+    sentence_term_code { "MyString" }
+    years { "MyString" }
+    months { "MyString" }
+    days { "MyString" }
+    sentence_term { "MyString" }
+    start_date { "2022-04-12" }
+    end_date { "2022-04-12" }
+    count_num { "MyString" }
+    order_code { "MyString" }
+    consecutive_to_count { "MyString" }
+    charge_status { "MyString" }
+  end
+end

--- a/spec/models/doc/historical_sentence_spec.rb
+++ b/spec/models/doc/historical_sentence_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Doc::HistoricalSentence, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
# Description

Adds tasks to import the following from the old DOC data set:

- [x] OffenderExits - Mapped to DOC Statuses
- [x] OffenderReceptions - Mapped to DOC Statuses
- [ ] OffenderSentence - Mapped to DOC Sentence - additional fields

**Additional Fields from the Offender Sentence**

- OrderID
- ChargeSeq
- OffenceDescription
- OffenceComment
- SentenceTermCode
- Years
- Months
- Days
- SentenceTerm
- StartDate
- EndDate
- CountNum
- OrderCode
- ConsecutiveToCount
- ChargeStatus