### PR TITLE
PD2-157 - Scrape judge before updating cases

### DIFF
--- a/app/services/scrapers/judges.rb
+++ b/app/services/scrapers/judges.rb
@@ -26,7 +26,7 @@ module Scrapers
       data = parsed_data.css('select[name="Judge"]')
       data.css('option').each do |o|
         j = Judge.find_or_initialize_by(oscn_id: o['value'])
-        j.name = o.text
+        j.name = o.text.chomp(',')
         j.first_name = o.text.split(',')[1]&.squish
         j.last_name = o.text.split(',')[0]&.squish
         j.save!

--- a/lib/tasks/update.rake
+++ b/lib/tasks/update.rake
@@ -4,6 +4,7 @@ require 'oscn_scraper'
 namespace :update do
   desc 'Scrape cases data'
   task cases: [:environment] do
+    Scrapers::Judges.perform
     Scrapers::Case.perform
   end
 


### PR DESCRIPTION
This will ensure we have data recent for all judges before running update. 
Alternatively can do on a cron job but this makes it a bit less error prone in-case running manually.
Also fixes bug where judges were being imported with a trailing comma