### PR TITLE
added where_not clause to exclude parties with no oscn_id  

### DIFF
--- a/app/models/party.rb
+++ b/app/models/party.rb
@@ -10,7 +10,6 @@ class Party < ApplicationRecord
   has_many :aliases, class_name: 'PartyAlias', dependent: :destroy
   has_one :party_html, dependent: :destroy
 
-  validates :oscn_id, presence: true
   validates :oscn_id, uniqueness: { case_sensitive: true }
   validates :birth_month, inclusion: 1..12, allow_nil: true
   validates :birth_year, inclusion: 1800..DateTime.current.year, allow_nil: true

--- a/app/services/scrapers/parties/high_priority.rb
+++ b/app/services/scrapers/parties/high_priority.rb
@@ -6,7 +6,7 @@ module Scrapers
       end
 
       def perform
-        parties_oscn_ids = ::Party.without_html.limit(parties_high_count).pluck(:oscn_id)
+        parties_oscn_ids = ::Party.without_html.where.not(oscn_id: nil).limit(parties_high_count).pluck(:oscn_id)
 
         bar = ProgressBar.new(parties_oscn_ids.count)
         puts "#{parties_oscn_ids.count} are missing html"

--- a/app/services/scrapers/parties/low_priority.rb
+++ b/app/services/scrapers/parties/low_priority.rb
@@ -4,7 +4,7 @@ module Scrapers
       attr :parties_oscn_ids
 
       def initialize(days_ago: 90, limit: low_count)
-        @parties_oscn_ids = ::Party.older_than(days_ago.days.ago).limit(limit).pluck(:oscn_id)
+        @parties_oscn_ids = ::Party.older_than(days_ago.days.ago).where.not(oscn_id: nil).limit(limit).pluck(:oscn_id)
       end
 
       def self.perform(days_ago: 90)

--- a/spec/models/party_spec.rb
+++ b/spec/models/party_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe Party, type: :model do
   end
 
   describe 'validations' do
-    it { should validate_presence_of(:oscn_id) }
     subject { FactoryBot.build(:party) }
     it { should validate_uniqueness_of(:oscn_id) }
   end

--- a/spec/services/scrapers/parties/high_priority.rb
+++ b/spec/services/scrapers/parties/high_priority.rb
@@ -13,6 +13,15 @@ RSpec.describe Scrapers::Parties::HighPriority do
         end
       end
     end
+    context 'when there is a party with no html and no oscn_id' do
+      let!(:party_no_oscn) { create(:party, oscn_id: nil) }
+
+      it 'doesnt add jobs to the PartyWorker' do
+        expect do
+          described_class.perform.to change(PartyWorker.jobs, :size).by(0)
+        end
+      end
+    end
 
     context 'when there is a party with html' do
       let!(:party_with_html) { create(:party, :with_html) }

--- a/spec/services/scrapers/parties/low_priority.rb
+++ b/spec/services/scrapers/parties/low_priority.rb
@@ -15,6 +15,17 @@ RSpec.describe Scrapers::Parties::HighPriority do
         end
       end
     end
+    context 'when there is a party with no html and no oscn_id' do
+      let!(:party_no_oscn) do
+        create(:party, oscn_id: nil)
+      end
+
+      it 'doesnt add jobs to the PartyWorker' do
+        expect do
+          described_class.perform.to change(PartyWorker.jobs, :size).by(0)
+        end
+      end
+    end
 
     context 'when there is a party that hasn\'t been scraped in a while' do
       let!(:old_party) do


### PR DESCRIPTION
in low and high priority party scrapers

also removed presence  validation for oscn_id in party's model
To test run rspec  on spec/services/scrapers/parties/high_priority.rb 
and
 spec/services/scrapers/parties/hlow_priority.rb