### PR TITLE
Set Party Scraping Priority

### DIFF
--- a/app/services/scrapers/parties/high_priority.rb
+++ b/app/services/scrapers/parties/high_priority.rb
@@ -12,7 +12,9 @@ module Scrapers
         puts "#{parties_oscn_ids.count} are missing html"
 
         parties_oscn_ids.each do |oscn_id|
-          PartyWorker.perform_async(oscn_id)
+          PartyWorker
+            .set(queue: :high)
+            .perform_async(oscn_id)
           bar.increment!
         end
       end

--- a/app/services/scrapers/parties/low_priority.rb
+++ b/app/services/scrapers/parties/low_priority.rb
@@ -16,7 +16,9 @@ module Scrapers
         bar = ProgressBar.new(parties_oscn_ids.count)
 
         parties_oscn_ids.each do |oscn_id|
-          PartyWorker.perform_async(oscn_id)
+          PartyWorker
+            .set(queue: :low)
+            .perform_async(oscn_id)
           bar.increment!
         end
       end


### PR DESCRIPTION
Currently the party scraper is getting push to the default queue but it should be finer tuned than that so we ensure everything is getting processed.