### PR TITLE
Add task to be able to trigger off just missing html cases

### DIFF
--- a/lib/tasks/update.rake
+++ b/lib/tasks/update.rake
@@ -86,7 +86,7 @@ namespace :update do
         .perform_async(c[0], c[1], true)
     end
   end
-  
+
   desc 'Set the is_error flag on court_cases'
   task is_error: [:environment] do
     associations = [:parties, :current_judge, :counsels, :counts, :events, :docket_events]


### PR DESCRIPTION
# Description

Sidekiq is getting backed up due to not all of the cases being processed each night. This is causing duplicate sidekiq jobs to be queued up for scraping, even though they are already in the queue.

This PR is a short term patch so that I can remove the whole queue on production and just trigger up the most important cases for scraping.