### PR TITLE
[DEV-789] Add Daily Filing worker

### DIFF
--- a/app/models/county.rb
+++ b/app/models/county.rb
@@ -3,4 +3,8 @@ class County < ApplicationRecord
   belongs_to :district_attorney, optional: true
 
   validates :name, :fips_code, presence: true
+
+  def self.name_id_mapping
+    pluck(:name, :id).to_h
+  end
 end

--- a/app/services/importers/new_court_case.rb
+++ b/app/services/importers/new_court_case.rb
@@ -7,7 +7,7 @@ module Importers
     def initialize(link)
       @case_number = link.text
       @case_types = CaseType.oscn_id_mapping
-      @counties = County.pluck(:name, :id).to_h
+      @counties = County.name_id_mapping
       @params = CGI.parse(URI(link['href']).query).to_h { |k, v| [k.downcase, v.first] }
     end
 

--- a/app/services/scrapers/daily_filing.rb
+++ b/app/services/scrapers/daily_filing.rb
@@ -1,0 +1,47 @@
+module Scrapers
+  class DailyFiling
+    attr_accessor :county, :date, :case_types, :counties
+    
+    def initialize(county, date)
+      @county = county
+      @date = date
+      @case_types = CaseType.pluck(:abbreviation, :id).to_h
+      @counties = County.pluck(:name, :id).to_h
+    end
+
+    def self.perform(county, date)
+      new(county, date).perform
+    end
+
+    def perform
+      data = fetch_html
+      data.css('tr a').each do |row|
+        # TODO: Change to use link parser when merged
+        # https://github.com/AyOK-Code/oscn_scraper/pull/31
+        uri = URI(row['href'])
+        params = CGI.parse(uri.query)
+        case_number = row.text
+        oscn_id = params['casemasterID'].first.to_i
+        county = params['db'].first
+        case_type = case_number.split('-').first
+        next if case_types[case_type].blank?
+
+        c = ::CourtCase.find_or_initialize_by(oscn_id: oscn_id, county_id: counties[county])
+        c.case_type_id = case_types[case_type]
+        c.case_number = row.text
+        c.filed_on = date
+        c.save!
+      end
+    end
+
+    private
+
+    def fetch_html
+      scraper = OscnScraper::Requestor::Report.new({ county: county, date: date })
+      html = scraper.fetch_daily_filings
+      Nokogiri::HTML(html.body)
+    end
+  end
+end
+
+

--- a/app/services/scrapers/daily_filing.rb
+++ b/app/services/scrapers/daily_filing.rb
@@ -1,12 +1,12 @@
 module Scrapers
   class DailyFiling
     attr_accessor :county, :date, :case_types, :counties
-    
+
     def initialize(county, date)
       @county = county
       @date = date
-      @case_types = CaseType.pluck(:abbreviation, :id).to_h
-      @counties = County.pluck(:name, :id).to_h
+      @case_types = CaseType.oscn_id_mapping
+      @counties = County.name_id_mapping
     end
 
     def self.perform(county, date)
@@ -43,5 +43,3 @@ module Scrapers
     end
   end
 end
-
-

--- a/app/services/scrapers/new_cases.rb
+++ b/app/services/scrapers/new_cases.rb
@@ -5,7 +5,7 @@ module Scrapers
 
     def initialize(county, days_ago: 7)
       @case_types = CaseType.oscn_id_mapping
-      @counties = County.pluck(:name, :id).to_h
+      @counties = County.name_id_mapping
       @county = county
       @days_ago = days_ago
     end
@@ -26,7 +26,7 @@ module Scrapers
         end
       end
     end
-    
+
     def save_case(row, date)
       params = OscnScraper::Parsers::Link.parse(row)
 

--- a/app/services/scrapers/new_cases.rb
+++ b/app/services/scrapers/new_cases.rb
@@ -26,7 +26,7 @@ module Scrapers
         end
       end
     end
-
+    
     def save_case(row, date)
       params = OscnScraper::Parsers::Link.parse(row)
 

--- a/app/workers/daily_filing_worker.rb
+++ b/app/workers/daily_filing_worker.rb
@@ -1,0 +1,11 @@
+# Worker that scrapes the Daily Filing report
+class DailyFilingWorker
+  include Sidekiq::Worker
+  include Sidekiq::Throttled::Worker
+  sidekiq_options retry: 5
+  sidekiq_throttle_as :oscn
+
+  def perform(county, date)
+    ::Scrapers::DailyFiling.perform(county, date)
+  end
+end

--- a/lib/tasks/court_cases.rake
+++ b/lib/tasks/court_cases.rake
@@ -1,37 +1,23 @@
 require 'uri'
 
 namespace :scrape do
-  desc 'Scrape cases data'
-  task :court_cases, [:year, :county] => [:environment] do |_t, args|
-    # TODO: Change to import task
+  desc 'Scrape cases into database for a given county and'
+  task :court_cases, [:year, :county, :months] => [:environment] do |_t, args|
+    args.with_defaults(:months => 12)
     year = args.year.to_i
+    months = args.months.to_i
     county = args.county
-    dates = (Date.new(year, 1, 1)..Date.new(year, 12, 31)).to_a
+    dates = (Date.new(year, 1, 1)..Date.new(year, months, 31)).to_a
     case_types = CaseType.oscn_id_mapping
     counties = County.pluck(:name, :id).to_h
+    bar = ProgressBar.new(dates.count)
 
-    dates.each do |date|
-      sleep(rand(3))
-      scraper = OscnScraper::Requestor::Report.new({ county: county, date: date })
-      html = scraper.fetch_daily_filings
-      data = Nokogiri::HTML(html.body)
-      puts "Pulling cases from #{date.strftime('%m/%d/%Y')}"
-
-      data.css('tr a').each do |row|
-        uri = URI(row['href'])
-        params = CGI.parse(uri.query)
-        case_number = row.text
-        oscn_id = params['casemasterID'].first.to_i
-        county = params['db'].first
-        case_type = case_number.split('-').first
-        next if case_types[case_type].blank?
-
-        c = ::CourtCase.find_or_initialize_by(oscn_id: oscn_id, county_id: counties[county])
-        c.case_type_id = case_types[case_type]
-        c.case_number = row.text
-        c.filed_on = date
-        c.save!
-      end
+    dates.each_with_index do |date, i|
+      bar.increment!
+      
+      DailyFilingWorker
+        .set(queue: :high)
+        .perform_async(county, date)
     end
   end
 end

--- a/lib/tasks/court_cases.rake
+++ b/lib/tasks/court_cases.rake
@@ -3,18 +3,16 @@ require 'uri'
 namespace :scrape do
   desc 'Scrape cases into database for a given county and'
   task :court_cases, [:year, :county, :months] => [:environment] do |_t, args|
-    args.with_defaults(:months => 12)
+    args.with_defaults(months: 12)
     year = args.year.to_i
     months = args.months.to_i
     county = args.county
     dates = (Date.new(year, 1, 1)..Date.new(year, months, 31)).to_a
-    case_types = CaseType.oscn_id_mapping
-    counties = County.pluck(:name, :id).to_h
     bar = ProgressBar.new(dates.count)
 
-    dates.each_with_index do |date, i|
+    dates.each do |date|
       bar.increment!
-      
+
       DailyFilingWorker
         .set(queue: :high)
         .perform_async(county, date)

--- a/spec/models/county_spec.rb
+++ b/spec/models/county_spec.rb
@@ -10,4 +10,13 @@ RSpec.describe County, type: :model do
     it { should have_many(:court_cases).dependent(:destroy) }
     it { should belong_to(:district_attorney).class_name('DistrictAttorney').optional }
   end
+
+  describe '#name_id_mapping' do
+    it 'returns a hash of the name to id' do
+      county = create(:county)
+      mapping = County.name_id_mapping
+
+      expect(mapping[county.name]).to eq county.id
+    end
+  end
 end


### PR DESCRIPTION
# Description

Add a worker to process the Daily Filing Report by date. This worker only pulls in the case_number, filed_on, oscn_id, case_type_id, and county_id. Once those values are pulled in, the scraper will pick up those cases in the nightly update.