### PR TITLE
Performance enhancements

### DIFF
--- a/app/models/court_case.rb
+++ b/app/models/court_case.rb
@@ -31,6 +31,7 @@ class CourtCase < ApplicationRecord
   # TODO: Make scope more dynamic to search for different errors
   scope :with_error, -> { where.not('logs @> ?', { events: nil }.to_json) }
   scope :for_county_name, ->(name) { joins(:county).where(counties: { name: name }) }
+  scope :not_in_queue, -> { where(enqueued: false) }
 
   delegate :html, to: :case_html
 

--- a/lib/tasks/update.rake
+++ b/lib/tasks/update.rake
@@ -76,12 +76,11 @@ namespace :update do
 
   desc 'Queue up cases missing html'
   task missing_html: [:environment] do
-    court_cases = CourtCase.without_html.select(:county_id, :case_number, :enqueued)
+    court_cases = CourtCase.without_html.not_in_queue.select(:county_id, :case_number)
     bar = ProgressBar.new(court_cases.length)
 
     court_cases.each do |c|
       bar.increment!
-      next if c.enqueued
       
       CourtCaseWorker
         .set(queue: :high)

--- a/lib/tasks/update.rake
+++ b/lib/tasks/update.rake
@@ -81,7 +81,7 @@ namespace :update do
 
     court_cases.each do |c|
       bar.increment!
-      
+
       CourtCaseWorker
         .set(queue: :high)
         .perform_async(c.county_id, c.case_number, true)

--- a/spec/models/court_case_spec.rb
+++ b/spec/models/court_case_spec.rb
@@ -140,7 +140,25 @@ RSpec.describe CourtCase, type: :model do
 
   describe '.for_county_name(name)' do
     it 'filters by the county name' do
+      skip
+    end
+  end
 
+  describe '.not_in_queue' do
+    context 'when court case is in queue' do
+      it 'does not return the case' do
+        court_case = create(:court_case, enqueued: true)
+
+        expect(CourtCase.not_in_queue.count).to eq 0
+      end
+    end
+
+    context 'when court case not in queue' do
+      it 'returns the case' do
+        court_case = create(:court_case, enqueued: false)
+
+        expect(CourtCase.not_in_queue.count).to eq 1
+      end
     end
   end
 


### PR DESCRIPTION
# Description

After fixing the bug, the total time to enqueue the 1.6 million cases was ~ 80 hrs. This was due to some unnecessary querying the CourtCases table. By only selecting Court Cases not in the queue in the initial SQL, we can avoid having to query for each case individually and checking whether the case is `enqueued`

Instead of implementing an index (as the branch name states), I simply loaded everything into memory at the beginning of the task.