### PR TITLE
Tweak logic for resolving warrants

### DIFF
--- a/app/services/scrapers/ocso_warrants.rb
+++ b/app/services/scrapers/ocso_warrants.rb
@@ -15,7 +15,8 @@ module Scrapers
           bond_amount: warrant_hash[:bond_amount],
           issued: warrant_hash[:issued],
           counts: warrant_hash[:counts],
-          updated_at: DateTime.now
+          updated_at: DateTime.now,
+          resolved_at: nil
         )
         warrant.save!
       end

--- a/app/services/scrapers/ocso_warrants.rb
+++ b/app/services/scrapers/ocso_warrants.rb
@@ -19,7 +19,7 @@ module Scrapers
         )
         warrant.save!
       end
-      ::Ocso::Warrant.where(resolved_at: nil).where("updated_at > ?", 7.days.ago).each do |warrant|
+      ::Ocso::Warrant.where(resolved_at: nil).where('updated_at > ?', 7.days.ago).each do |warrant|
         warrant.update!(resolved_at: warrant.updated_at + 1.day)
       end
     end

--- a/app/services/scrapers/ocso_warrants.rb
+++ b/app/services/scrapers/ocso_warrants.rb
@@ -2,7 +2,6 @@ module Scrapers
   class OcsoWarrants < ApplicationService
     def perform
       warrant_hashes = OcsoScraper::Crawler.perform
-      upserted_warrant_ids = []
       warrant_hashes.each do |warrant_hash|
         warrant = ::Ocso::Warrant.find_or_initialize_by(
           first_name: warrant_hash[:first_name],
@@ -15,13 +14,13 @@ module Scrapers
           case_number: warrant_hash[:case_number],
           bond_amount: warrant_hash[:bond_amount],
           issued: warrant_hash[:issued],
-          counts: warrant_hash[:counts]
+          counts: warrant_hash[:counts],
+          updated_at: DateTime.now
         )
         warrant.save!
-        upserted_warrant_ids << warrant.id
       end
-      ::Ocso::Warrant.where(resolved_at: nil).where.not(id: upserted_warrant_ids).each do |warrant|
-        warrant.update!(resolved_at: Time.current)
+      ::Ocso::Warrant.where(resolved_at: nil).where(updated_at: 7.days.ago).each do |warrant|
+        warrant.update!(resolved_at: warrant.updated_at + 1.day)
       end
     end
   end

--- a/app/services/scrapers/ocso_warrants.rb
+++ b/app/services/scrapers/ocso_warrants.rb
@@ -19,7 +19,7 @@ module Scrapers
         )
         warrant.save!
       end
-      ::Ocso::Warrant.where(resolved_at: nil).where(updated_at: 7.days.ago).each do |warrant|
+      ::Ocso::Warrant.where(resolved_at: nil).where("updated_at > ?", 7.days.ago).each do |warrant|
         warrant.update!(resolved_at: warrant.updated_at + 1.day)
       end
     end


### PR DESCRIPTION
# Description

There is a data issue for the OCSO warrants table where a huge amount of warrants were incorrectly marked as resolved in the database on March 7th and Match 29th.

| Month | Day | Resolved Count |
| ------------- |:-------------:| -----:|
| 3 | 7 | 40369 |
| 3 | 29 | 44280 |

You can replicate the counts of above with this SQL:

```sql
SELECT EXTRACT(MONTH FROM resolved_at), EXTRACT(DAY FROM resolved_at), COUNT(*) FROM ocso_warrants
GROUP BY EXTRACT(MONTH from resolved_at), EXTRACT(DAY FROM resolved_at)
```

I'm still unclear what actually caused the underlying issue. My best guess is there was some sort of outage on the OCSO site that cause huge numbers of cases to not be found.

# Proposed solution

Instead of relying on the scraper storing the cases in memory, which could cause issue in the case of OCSO site outages, I've adjusted the scraper to leverage the `updated_at` field anytime the warrant seen on the site. Leveraging this new datapoint, the scraper then looks for any cases that have not been seen on the site in the past 7 days. If it hasn't been seen in 7 days, the warrant is safe to be marked as resolved. To try to capture the correct `resolved_at` date, it uses the `updated_at` field plus one day.

This new methodology will cause a 7-day delay in resolved warrants being displayed on the PowerBI visualizations, but will make it so that cases will not be resolved based not showing up on the site for a single day.

### Fixing the Data

I think the best way to fix the data would be to just toggle warrants from those two days as not resolved (`resolved_at = NULL`) and see if they show up as unresolved again in the next 24-hrs.