### PR TITLE
Add one off scraping from search

### DIFF
--- a/app/services/scrapers/one_off_case.rb
+++ b/app/services/scrapers/one_off_case.rb
@@ -27,9 +27,7 @@ module Scrapers
         c.case_type_id = case_types[case_type]
         c.case_number = row[:case_number]
         c.save!
-        c.reload
         
-        c.update(enqueued: true)
         ::Importers::CaseHtml.perform(county_id, c.case_number)
         ::Importers::CourtCase.perform(county_id, c.case_number)
       end

--- a/app/services/scrapers/one_off_case.rb
+++ b/app/services/scrapers/one_off_case.rb
@@ -1,0 +1,41 @@
+module Scrapers
+  class OneOffCase
+    attr_accessor :county, :case_number, :case_types, :counties
+
+    def initialize(county, case_number)
+      @county = county
+      @case_number = case_number
+      @case_types = CaseType.oscn_id_mapping
+      @counties = County.name_id_mapping
+    end
+
+    def self.perform(county, date)
+      new(county, date).perform
+    end
+
+    def perform
+      html = OscnScraper::Requestor::Search.fetch_cases({ db: 'all', number: case_number })
+      parsed_html = Nokogiri::HTML(html.body)
+      data = OscnScraper::Parsers::Search.parse(parsed_html, county.downcase)
+      county_id = counties[county]
+
+      data.each do |row|
+        case_type = row[:case_number].split('-').first
+        next if case_types[case_type].blank?
+
+        c = ::CourtCase.find_or_initialize_by(oscn_id: row[:oscn_id], county_id: county_id)
+        c.case_type_id = case_types[case_type]
+        c.case_number = row[:case_number]
+        c.save!
+        c.reload
+        
+        c.update(enqueued: true)
+        ::Importers::CaseHtml.perform(county_id, c.case_number)
+        ::Importers::CourtCase.perform(county_id, c.case_number)
+      end
+    end
+  end
+end
+
+
+    

--- a/app/services/scrapers/one_off_case.rb
+++ b/app/services/scrapers/one_off_case.rb
@@ -27,13 +27,10 @@ module Scrapers
         c.case_type_id = case_types[case_type]
         c.case_number = row[:case_number]
         c.save!
-        
+
         ::Importers::CaseHtml.perform(county_id, c.case_number)
         ::Importers::CourtCase.perform(county_id, c.case_number)
       end
     end
   end
 end
-
-
-    

--- a/app/workers/one_off_case_worker.rb
+++ b/app/workers/one_off_case_worker.rb
@@ -1,0 +1,14 @@
+require 'importers/court_case'
+# Finds the case from the search screen
+# Scrapes the case and imports into database
+# Ex: https://www.oscn.net/dockets/GetCaseInformation.aspx?db=tulsa&number=CF-2018-1016
+class OneOffCaseWorker
+  include Sidekiq::Worker
+  include Sidekiq::Throttled::Worker
+  sidekiq_options retry: 5, queue: :medium
+  sidekiq_throttle_as :oscn
+
+  def perform(county, case_number)
+    ::Scrapers::OneOffCase.perform(county, case_number)
+  end
+end

--- a/lib/tasks/one-off/missing_cases.rake
+++ b/lib/tasks/one-off/missing_cases.rake
@@ -1,0 +1,11 @@
+
+namespace :update do
+  desc 'Update cases for data request'
+  task missing_cases: [:environment] do
+    data = Bucket.new.get_object("missing_case_numbers.csv")
+
+    data.each do |row|
+      
+    end
+  end
+end

--- a/lib/tasks/one-off/missing_cases.rake
+++ b/lib/tasks/one-off/missing_cases.rake
@@ -2,10 +2,11 @@
 namespace :update do
   desc 'Update cases for data request'
   task missing_cases: [:environment] do
-    data = Bucket.new.get_object("missing_case_numbers.csv")
+    resp = Bucket.new.get_object("missing_case_numbers.csv")
+    data = CSV.parse(resp.body.read, headers: true)
 
     data.each do |row|
-      
+      Scrapers::OneOffCase.new('Oklahoma', row[0]).perform   
     end
   end
 end

--- a/lib/tasks/one-off/missing_cases.rake
+++ b/lib/tasks/one-off/missing_cases.rake
@@ -6,7 +6,9 @@ namespace :update do
     data = CSV.parse(resp.body.read, headers: true)
 
     data.each do |row|
-      Scrapers::OneOffCase.new('Oklahoma', row[0]).perform   
+      OneOffCaseWorker
+          .set(queue: :high)
+          .perform_async('Oklahoma', row[0])
     end
   end
 end

--- a/lib/tasks/one-off/missing_cases.rake
+++ b/lib/tasks/one-off/missing_cases.rake
@@ -1,14 +1,13 @@
-
 namespace :update do
   desc 'Update cases for data request'
   task missing_cases: [:environment] do
-    resp = Bucket.new.get_object("missing_case_numbers.csv")
+    resp = Bucket.new.get_object('missing_case_numbers.csv')
     data = CSV.parse(resp.body.read, headers: true)
 
     data.each do |row|
       OneOffCaseWorker
-          .set(queue: :high)
-          .perform_async('Oklahoma', row[0])
+        .set(queue: :high)
+        .perform_async('Oklahoma', row[0])
     end
   end
 end


### PR DESCRIPTION
# Description

Adds the ability to scrape one off cases into the database using the search functionality. The `OneOffCaseWorker` will take any county / case_number combination and do the following:

- Use the OSCN search functionality to see if the case exists
- If the case exists, it goes to scrape that case and import it into the database

There is also a one-off task to update some missing cases for a request from Austin