### PR TITLE
Add county_name arg to task

### DIFF
--- a/lib/tasks/missing_cases.rake
+++ b/lib/tasks/missing_cases.rake
@@ -1,13 +1,13 @@
 namespace :update do
   desc 'Update cases for data request'
-  task missing_cases: [:environment] do
+  task :missing_cases, [:county_name] => [:environment] do |_t, args|
     resp = Bucket.new.get_object('missing_case_numbers.csv')
     data = CSV.parse(resp.body.read, headers: true)
 
     data.each do |row|
       OneOffCaseWorker
         .set(queue: :high)
-        .perform_async('Oklahoma', row[0])
+        .perform_async(arg.county_name, row[0])
     end
   end
 end


### PR DESCRIPTION
# Description

Adds the arg `county_name` to the missing_cases rake task so that it can be used for any county. Also moves the task out of the one-off folder since it is proving to be useful