### PR TITLE
Update the party importer to query database rather than store id mapping in memory

### DIFF
--- a/app/services/importers/party.rb
+++ b/app/services/importers/party.rb
@@ -49,7 +49,7 @@ module Importers
       params['id'].first.to_i
     end
 
-    def save_existing_party_to_case(party, oscn_id)
+    def save_existing_party_to_case(party)
       create_case_party(court_case.id, party.id)
     end
 

--- a/app/services/importers/party.rb
+++ b/app/services/importers/party.rb
@@ -29,7 +29,7 @@ module Importers
 
     def save_parties(party_data)
       oscn_id = parse_id(party_data[:link])
-      party = Party.find_by(oscn_id: oscn_id)
+      party = ::Party.find_by(oscn_id: oscn_id)
 
       if party
         party.update(full_name: party_data[:name])

--- a/app/services/importers/party.rb
+++ b/app/services/importers/party.rb
@@ -1,13 +1,12 @@
 module Importers
   # Saves Party information to the database
   class Party
-    attr_reader :parties_json, :parties, :party_types
+    attr_reader :parties_json, :party_types
     attr_accessor :court_case, :logs
 
     def initialize(parties_json, court_case, logs)
       @parties_json = parties_json
       @court_case = court_case
-      @parties = ::Party.pluck(:oscn_id, :id).to_h
       @party_types = ::PartyType.pluck(:name, :id).to_h
       @logs = logs
     end
@@ -30,10 +29,11 @@ module Importers
 
     def save_parties(party_data)
       oscn_id = parse_id(party_data[:link])
+      party = Party.find_by(oscn_id: oscn_id)
 
-      if parties[oscn_id]
-        update_party(parties[oscn_id], party_data)
-        save_existing_party_to_case(oscn_id)
+      if party
+        party.update(full_name: party_data[:name])
+        save_existing_party_to_case(party, oscn_id)
       else
         create_and_save_party_to_case(oscn_id, party_data)
       end
@@ -49,16 +49,8 @@ module Importers
       params['id'].first.to_i
     end
 
-    def update_party(party_id, party_data)
-      party = ::Party.find(party_id)
-      party.update(
-        full_name: party_data[:name]
-      )
-    end
-
-    def save_existing_party_to_case(oscn_id)
-      party_id = parties[oscn_id]
-      create_case_party(court_case.id, party_id)
+    def save_existing_party_to_case(party, oscn_id)
+      create_case_party(court_case.id, party.id)
     end
 
     def find_or_create_party_type(party_type)

--- a/app/services/importers/party.rb
+++ b/app/services/importers/party.rb
@@ -33,7 +33,7 @@ module Importers
 
       if party
         party.update(full_name: party_data[:name])
-        save_existing_party_to_case(party, oscn_id)
+        save_existing_party_to_case(party)
       else
         create_and_save_party_to_case(oscn_id, party_data)
       end


### PR DESCRIPTION
# Description

Changes the party importer so that it queries the database rather than storing the `oscn_id` internal `id` mapping in memory. This should greatly improve the performance of the PartyWorker and reduce the load on both the database and the workers.

### Related Test

Run test: `rspec spec/services/importers/party_spec.rb`