### PR TITLE
[DEV-1144] Case Not Found log

### DIFF
--- a/app/models/case_not_found.rb
+++ b/app/models/case_not_found.rb
@@ -1,0 +1,5 @@
+class CaseNotFound < ApplicationRecord
+  belongs_to :county
+
+  validates :case_number, presence: true
+end

--- a/app/models/county.rb
+++ b/app/models/county.rb
@@ -1,5 +1,6 @@
 class County < ApplicationRecord
   has_many :court_cases, dependent: :destroy
+  has_many :case_not_founds, dependent: :destroy
   belongs_to :district_attorney, optional: true
 
   validates :name, :fips_code, presence: true

--- a/app/services/scrapers/one_off_case.rb
+++ b/app/services/scrapers/one_off_case.rb
@@ -1,37 +1,63 @@
 module Scrapers
   class OneOffCase
-    attr_accessor :county, :case_number, :case_types, :counties
+    attr_accessor :county, :case_number, :case_types
 
     def initialize(county, case_number)
       @county = county
       @case_number = case_number
       @case_types = CaseType.oscn_id_mapping
-      @counties = County.name_id_mapping
+      @county = County.find_by(name: county)
     end
 
-    def self.perform(county, date)
-      new(county, date).perform
+    def self.perform(county, case_number)
+      new(county, case_number).perform
     end
 
     def perform
-      html = OscnScraper::Requestor::Search.fetch_cases({ db: 'all', number: case_number })
-      parsed_html = Nokogiri::HTML(html.body)
-      data = OscnScraper::Parsers::Search.parse(parsed_html, county.downcase)
-      # TODO: DEV-1144 Log if case was not found
-      county_id = counties[county]
+      check_not_found = CaseNotFound.find_by(county_id: county.id, case_number: case_number)
+
+      return if check_not_found.present?
+
+      parsed_html = scrape_html
+      data = parse_html(parsed_html)
+      create_missing_case if data.empty?
 
       data.each do |row|
-        case_type = row[:case_number].split('-').first
-        next if case_types[case_type].blank?
+        case_type_id = find_case_type(row)
+        next if case_type_id.blank?
 
-        c = ::CourtCase.find_or_initialize_by(oscn_id: row[:oscn_id], county_id: county_id)
-        c.case_type_id = case_types[case_type]
-        c.case_number = row[:case_number]
-        c.save!
+        create_court_case(row, case_type_id)
 
-        ::Importers::CaseHtml.perform(county_id, c.case_number)
-        ::Importers::CourtCase.perform(county_id, c.case_number)
+        ::Importers::CaseHtml.perform(county_id, case_number)
+        ::Importers::CourtCase.perform(county_id, case_number)
       end
+    end
+
+    private
+
+    def scrape_html
+      html = OscnScraper::Requestor::Search.fetch_cases({ db: 'all', number: case_number })
+      Nokogiri::HTML(html.body)
+    end
+
+    def parse_html(html)
+      OscnScraper::Parsers::Search.parse(html, county.downcase)
+    end
+
+    def create_missing_case
+      CaseNotFound.find_or_create_by(county_id: county.id, case_number: case_number)
+    end
+
+    def find_case_type(row)
+      case_type = row[:case_number].split('-').first
+      case_types[case_type]
+    end
+
+    def create_court_case(row, case_type_id)
+      c = ::CourtCase.find_or_initialize_by(oscn_id: row[:oscn_id], county_id: county.id)
+      c.case_type_id = case_type_id
+      c.case_number = row[:case_number]
+      c.save!
     end
   end
 end

--- a/app/services/scrapers/one_off_case.rb
+++ b/app/services/scrapers/one_off_case.rb
@@ -41,7 +41,7 @@ module Scrapers
     end
 
     def parse_html(html)
-      OscnScraper::Parsers::Search.parse(html, county.downcase)
+      OscnScraper::Parsers::Search.parse(html, county.name.downcase)
     end
 
     def create_missing_case

--- a/app/services/scrapers/one_off_case.rb
+++ b/app/services/scrapers/one_off_case.rb
@@ -17,6 +17,7 @@ module Scrapers
       html = OscnScraper::Requestor::Search.fetch_cases({ db: 'all', number: case_number })
       parsed_html = Nokogiri::HTML(html.body)
       data = OscnScraper::Parsers::Search.parse(parsed_html, county.downcase)
+      # TODO: DEV-1144 Log if case was not found
       county_id = counties[county]
 
       data.each do |row|

--- a/db/migrate/20230703210127_create_case_not_founds.rb
+++ b/db/migrate/20230703210127_create_case_not_founds.rb
@@ -1,0 +1,10 @@
+class CreateCaseNotFounds < ActiveRecord::Migration[7.0]
+  def change
+    create_table :case_not_founds do |t|
+      t.references :county, null: false, foreign_key: true
+      t.string :case_number, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_21_122027) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_03_210127) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "plpgsql"
@@ -22,6 +22,14 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_21_122027) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["court_case_id"], name: "index_case_htmls_on_court_case_id"
+  end
+
+  create_table "case_not_founds", force: :cascade do |t|
+    t.bigint "county_id", null: false
+    t.string "case_number", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["county_id"], name: "index_case_not_founds_on_county_id"
   end
 
   create_table "case_parties", force: :cascade do |t|
@@ -593,6 +601,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_21_122027) do
   end
 
   add_foreign_key "case_htmls", "court_cases"
+  add_foreign_key "case_not_founds", "counties"
   add_foreign_key "case_parties", "court_cases"
   add_foreign_key "case_parties", "parties"
   add_foreign_key "case_parties", "rosters"

--- a/spec/factories/case_not_founds.rb
+++ b/spec/factories/case_not_founds.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :case_not_found do
+    county { nil }
+    case_number { "MyString" }
+  end
+end

--- a/spec/factories/case_not_founds.rb
+++ b/spec/factories/case_not_founds.rb
@@ -1,10 +1,6 @@
 FactoryBot.define do
   factory :case_not_found do
-    county { nil }
-<<<<<<< Updated upstream
-    case_number { "MyString" }
-=======
-    case_number { 'MyString' }
->>>>>>> Stashed changes
+    county
+    case_number { "CF-#{Faker::Number.between(from: 1990, to: 2025)}-#{Faker::Number.between(from: 1, to: 1000)}" }
   end
 end

--- a/spec/factories/case_not_founds.rb
+++ b/spec/factories/case_not_founds.rb
@@ -1,6 +1,10 @@
 FactoryBot.define do
   factory :case_not_found do
     county { nil }
+<<<<<<< Updated upstream
     case_number { "MyString" }
+=======
+    case_number { 'MyString' }
+>>>>>>> Stashed changes
   end
 end

--- a/spec/models/case_not_found_spec.rb
+++ b/spec/models/case_not_found_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe CaseNotFound, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/county_spec.rb
+++ b/spec/models/county_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe County, type: :model do
 
   describe 'associations' do
     it { should have_many(:court_cases).dependent(:destroy) }
+    it { should have_many(:case_not_founds).dependent(:destroy) }
     it { should belong_to(:district_attorney).class_name('DistrictAttorney').optional }
   end
 

--- a/spec/services/scrapers/one_off_case_spec.rb
+++ b/spec/services/scrapers/one_off_case_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+require 'sidekiq/testing'
+Sidekiq::Testing.fake!
+
+RSpec.describe Scrapers::OneOffCase do
+  describe '#perform' do
+    context 'when the case has been searched before' do
+      it 'does not send the request' do
+        search = OscnScraper::Requestor::Search
+        county = create(:county, name: 'Oklahoma')
+        not_found = create(:case_not_found, county_id: county.id, case_number: 'CF-2022-123456')
+
+        expect(search).not_to receive(:fetch_cases)
+        described_class.perform('Oklahoma', not_found.case_number)
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Description

Adds a log of cases that were not found when searching for them via the Search page. This will prevent unnecessary requests around searching for old cases that have already been searched for.