### PR TITLE
Add rescue for cases not found

### DIFF
--- a/app/services/scrapers/high_priority.rb
+++ b/app/services/scrapers/high_priority.rb
@@ -18,14 +18,19 @@ module Scrapers
       bar = ProgressBar.new(cases.count)
       puts "#{cases.count} are high priority for update for #{county.name} county"
       cases.each do |case_number|
-        court_case = ::CourtCase.find_by!(county_id: @county.id, case_number: case_number)
+        begin
+          court_case = ::CourtCase.find_by!(county_id: @county.id, case_number: case_number)
+        rescue ActiveRecord::RecordNotFound => e
+          Raygun.track_exception(e, custom_data: { error_type: 'CaseNotFound' })
+          next
+        else
+          next if court_case.enqueued
 
-        next if court_case.enqueued
-
-        court_case.update(enqueued: true)
-        CourtCaseWorker
-          .set(queue: :high)
-          .perform_async(@county.id, case_number, true)
+          court_case.update(enqueued: true)
+          CourtCaseWorker
+            .set(queue: :high)
+            .perform_async(@county.id, case_number, true)
+        end
         bar.increment!
       end
     end


### PR DESCRIPTION
# Description

Prevent breaking the loop when Court Case is not found in the database.