### PR TITLE
Adjust issues filed_by to be string

### DIFF
--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -1,6 +1,5 @@
 class Issue < ApplicationRecord
   belongs_to :court_case
   belongs_to :count_code
-  belongs_to :filed_by, class_name: 'Party'
   has_many :issue_parties, dependent: :destroy
 end

--- a/app/services/importers/issue.rb
+++ b/app/services/importers/issue.rb
@@ -1,14 +1,13 @@
 module Importers
   # Imports Issue data from parsed json
   class Issue
-    attr_accessor :court_case, :party_matcher, :logs, :count_codes
+    attr_accessor :court_case, :logs, :count_codes
     attr_reader :issues_json
 
     def initialize(issues_json, court_case, logs)
       @issues_json = issues_json
       @court_case = court_case
       @count_codes = CountCode.pluck(:code, :id).to_h
-      @party_matcher = Matchers::Party.new(court_case)
       @logs = logs
     end
 
@@ -45,8 +44,8 @@ module Importers
 
       {
         name: issue_data[:issue_name],
-        filed_by_id: party_matcher.party_id_from_name(issue_data[:filed_by]),
-        filed_on: issue_data[:filed_on],
+        filed_by: issue_data[:filed_by],
+        filed_on: issue_data[:filed_on] == 'Not Available' ? nil : issue_data[:filed_on],
         count_code_id: code_id
       }
     end

--- a/app/services/importers/issue_party.rb
+++ b/app/services/importers/issue_party.rb
@@ -33,7 +33,6 @@ module Importers
       ip.assign_attributes(issue_party_attributes(issue_party_data))
 
       begin
-        ap ip
         ip.save!
       rescue StandardError
         message = "#{issue.court_case.case_number}: Error creating issue party"

--- a/db/migrate/20230718120638_update_filed_by_to_string.rb
+++ b/db/migrate/20230718120638_update_filed_by_to_string.rb
@@ -1,0 +1,6 @@
+class UpdateFiledByToString < ActiveRecord::Migration[7.0]
+  def change
+    remove_reference :issues, :filed_by, index: true, foreign_key: { to_table: :parties }
+    add_column :issues, :filed_by, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_03_210127) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_18_120638) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "plpgsql"
@@ -336,13 +336,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_03_210127) do
     t.string "name"
     t.bigint "court_case_id", null: false
     t.bigint "count_code_id", null: false
-    t.bigint "filed_by_id", null: false
     t.date "filed_on"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "filed_by"
     t.index ["count_code_id"], name: "index_issues_on_count_code_id"
     t.index ["court_case_id"], name: "index_issues_on_court_case_id"
-    t.index ["filed_by_id"], name: "index_issues_on_filed_by_id"
   end
 
   create_table "judges", force: :cascade do |t|
@@ -666,7 +665,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_03_210127) do
   add_foreign_key "issue_parties", "verdicts"
   add_foreign_key "issues", "count_codes"
   add_foreign_key "issues", "court_cases"
-  add_foreign_key "issues", "parties", column: "filed_by_id"
   add_foreign_key "judges", "counties"
   add_foreign_key "okc_blotter_bookings", "okc_blotter_pdfs", column: "pdf_id"
   add_foreign_key "okc_blotter_bookings", "rosters"

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe Issue, type: :model do
   describe 'associations' do
     it { should belong_to(:count_code) }
     it { should belong_to(:court_case) }
-    it { should belong_to(:filed_by).class_name('Party') }
     it { should have_many(:issue_parties).dependent(:destroy) }
   end
 end


### PR DESCRIPTION
# Description

The `filed_by` is not always a person on the case. This was casing the issues to not be created in many cases. Changing this field to a string will allow the issues to be created on the case