### PR TITLE
Fix json serialization on daily filing

### DIFF
--- a/lib/tasks/court_cases.rake
+++ b/lib/tasks/court_cases.rake
@@ -15,7 +15,7 @@ namespace :scrape do
 
     dates.each do |date|
       bar.increment! unless Rails.env.test?
-      
+
       DailyFilingWorker
         .set(queue: :high)
         .perform_async(county_name, date.strftime('%Y-%m-%d'))

--- a/lib/tasks/court_cases.rake
+++ b/lib/tasks/court_cases.rake
@@ -15,10 +15,10 @@ namespace :scrape do
 
     dates.each do |date|
       bar.increment! unless Rails.env.test?
-
+      
       DailyFilingWorker
         .set(queue: :high)
-        .perform_async(county_name, date)
+        .perform_async(county_name, date.strftime('%Y-%m-%d'))
     end
   end
 end

--- a/spec/lib/tasks/court_cases_spec.rb
+++ b/spec/lib/tasks/court_cases_spec.rb
@@ -8,5 +8,6 @@ RSpec.describe 'scrape:court_cases', type: :task do
     expect do
       Rake::Task['scrape:court_cases'].invoke(2020, 'Oklahoma', 1)
     end.to change(DailyFilingWorker.jobs, :size).by(31)
+    expect(DailyFilingWorker.jobs.first['args']).to eq(['Oklahoma', '2020-01-01']
   end
 end

--- a/spec/lib/tasks/court_cases_spec.rb
+++ b/spec/lib/tasks/court_cases_spec.rb
@@ -8,6 +8,6 @@ RSpec.describe 'scrape:court_cases', type: :task do
     expect do
       Rake::Task['scrape:court_cases'].invoke(2020, 'Oklahoma', 1)
     end.to change(DailyFilingWorker.jobs, :size).by(31)
-    expect(DailyFilingWorker.jobs.first['args']).to eq(['Oklahoma', '2020-01-01']
+    expect(DailyFilingWorker.jobs.first['args']).to eq(['Oklahoma', '2020-01-01'])
   end
 end


### PR DESCRIPTION
# Description

Fixes the warnings from JSON serialization

```
WARN: Job arguments to DailyFilingWorker do not serialize to JSON safely. This will raise an error in
Sidekiq 7.0. See https://github.com/mperham/sidekiq/wiki/Best-Practices or raise an error today
by calling `Sidekiq.strict_args!` during Sidekiq initialization.
```