### PR TITLE
Update bundler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -467,4 +467,4 @@ RUBY VERSION
    ruby 3.1.3p185
 
 BUNDLED WITH
-   2.1.4
+   2.4.18


### PR DESCRIPTION
# Description

Post Rails upgrade, getting this message:

```
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
Bundler version 2.1.4
```

Due to bundler being out of date