### PR TITLE
Set legacy connection to false

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -21,7 +21,7 @@ Bundler.require(*Rails.groups)
 
 module BackendTemplate
   class Application < Rails::Application
-    config.load_defaults 6.0
+    config.load_defaults 7.0
 
     # Add this for Sidekiq UI
     config.session_store :cookie_store, key: '_interslice_session'

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -42,6 +42,9 @@ Rails.application.configure do
   # Highlight code that triggered database queries in logs.
   config.active_record.verbose_query_logs = true
 
+  # New connection handling
+  config.active_record.legacy_connection_handling
+
 
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -82,6 +82,9 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
+  # New connection handling
+  config.active_record.legacy_connection_handling
+
   # Inserts middleware to perform automatic connection switching.
   # The `database_selector` hash is used to pass options to the DatabaseSelector
   # middleware. The `delay` is used to determine how long to wait after a write

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -28,6 +28,9 @@ Rails.application.configure do
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false
 
+  # New connection handling
+  config.active_record.legacy_connection_handling
+
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false
 

--- a/config/initializers/httpparty.rb
+++ b/config/initializers/httpparty.rb
@@ -4,4 +4,4 @@ require 'openssl'
 # this only popped up when we added proxy server but *seems* to be happening without the proxy server
 # happens intermittently on both heroku and locally
 # todo: figure out how we can remove this?
-OpenSSL::SSL::VERIFY_PEER = OpenSSL::SSL::VERIFY_NONE
+# OpenSSL::SSL::VERIFY_PEER = OpenSSL::SSL::VERIFY_NONE

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -69,7 +69,7 @@ RSpec.configure do |config|
 
   # Configure FactoryBot
   config.include FactoryBot::Syntax::Methods
-  config.before(:suite, type: :task) do
+  config.before(:suite) do
     Rails.application.load_tasks
   end
 end


### PR DESCRIPTION
# Description

Receiving this warning when running test suite since #177 :

```
DEPRECATION WARNING: Using legacy connection handling is deprecated. Please set
`legacy_connection_handling` to `false` in your application.

The new connection handling does not support `connection_handlers`
getter and setter.

Read more about how to migrate at: https://guides.rubyonrails.org/active_record_multiple_databases.html#migrate-to-the-new-connection-handling
 (called from <top (required)> at /Users/holdenmitchell/code/oscn/config/environment.rb:5)
```

Also, getting this warning:

```
DEPRECATION WARNING: Non-URL-safe CSRF tokens are deprecated. Use 6.1 defaults or above. (called from <top (required)> at /Users/holdenmitchell/code/oscn/spec/rails_helper.rb:29)
```

And this one:

```
WARNING: `:suite` hooks do not support metadata since they apply to the suite as a whole rather than any individual example or example group that has metadata. The metadata you have provided ([{:type=>:task}]) will be ignored.
```

This PR resolves these warnings