### PR TITLE
Explicitly set money rounding in config

### DIFF
--- a/config/initializers/money.rb
+++ b/config/initializers/money.rb
@@ -1,1 +1,2 @@
 Money.default_currency = :usd
+Money.rounding_mode = BigDecimal::ROUND_HALF_EVEN


### PR DESCRIPTION
# Description

Fixes this warning message when running test suite

```
[WARNING] The default rounding mode will change from `ROUND_HALF_EVEN` to `ROUND_HALF_UP` in the next major release. Set it explicitly using `Money.rounding_mode=` to avoid potential problems.
```