### PR TITLE
Fix scope

### DIFF
--- a/app/models/eviction_letter.rb
+++ b/app/models/eviction_letter.rb
@@ -12,7 +12,7 @@ class EvictionLetter < ApplicationRecord
 
   scope :missing_address_validation, -> { where(is_validated: false) }
   scope :has_address_validation, -> { where(is_validated: true) }
-  scope :missing_extraction, -> { where.not(ocr_plaintiff_address: nil) }
+  scope :missing_extraction, -> { where(ocr_plaintiff_address: nil) }
   scope :has_extraction, -> { where.not(ocr_plaintiff_address: nil) }
 
   def full_name

--- a/lib/tasks/one-off/historical_letters.rake
+++ b/lib/tasks/one-off/historical_letters.rake
@@ -13,8 +13,11 @@ namespace :historical do
 
   desc 'Extracts historical eviction pdfs'
   task :extract, [:count] => [:environment] do |_t, args|
-    count = args.count || 100
+    count = args.count.to_i || 100
+    bar = ProgressBar.new(count)
+
     EvictionLetter.historical.missing_extraction.each_with_index do |letter, i|
+      bar.increment!
       EvictionOcr::Extractor.perform(letter.docket_event_link.document.url)
       break if i > count
     end
@@ -23,7 +26,10 @@ namespace :historical do
   desc 'Validate addresses'
   task :validate, [:count] => [:environment] do |_t, args|
     count = args.count || 100
+    bar = ProgressBar.new(count)
+
     EvictionLetter.historical.has_extraction.missing_address_validation.each_with_index do |letter, i|
+      bar.increment!
       EvictionOcr::AddressValidator.perform(letter.id)
       break if i > count
     end

--- a/spec/models/eviction_letter_spec.rb
+++ b/spec/models/eviction_letter_spec.rb
@@ -51,8 +51,8 @@ RSpec.describe EvictionLetter, type: :model do
 
   describe '#missing_extraction' do
     it 'returns letters that have not been extracted' do
-      create(:eviction_letter, ocr_plaintiff_address: nil)
-      eviction_letter = create(:eviction_letter, ocr_plaintiff_address: '123 Main St')
+      eviction_letter = create(:eviction_letter, ocr_plaintiff_address: nil)
+      create(:eviction_letter, ocr_plaintiff_address: '123 Main St')
 
       expect(EvictionLetter.missing_extraction).to eq([eviction_letter])
     end


### PR DESCRIPTION
# Description

Fixes the eviction letter scope `missing_extraction`