### PR TITLE
Add the email adjustments for evictions mailer

### DIFF
--- a/app/mailers/evictions_mailer.rb
+++ b/app/mailers/evictions_mailer.rb
@@ -1,6 +1,9 @@
 class EvictionsMailer < ApplicationMailer
-  def file_email(eviction_file_id)
+  def file_email(eviction_file_id, date_range)
     @eviction_file = EvictionFile.find(eviction_file_id)
+    @generated_at = @eviction_file.generated_at.in_time_zone('Central Time (US & Canada)')
+    @start = date_range[:start]
+    @finish = date_range[:finish]
 
     # Ensure there's a file attached before attempting to attach it
     raise 'No file attached to the EvictionFile' unless @eviction_file.file.attached?
@@ -12,6 +15,7 @@ class EvictionsMailer < ApplicationMailer
 
     @eviction_file.update!(sent_at: Time.zone.now)
 
-    mail(to: ENV.fetch('EVICTIONS_EMAIL', 'hmitchell@9bcorp.com'), subject: "Evictions File ID: #{@eviction_file.id}")
+    mail(to: ENV.fetch('EVICTIONS_EMAIL', 'hmitchell@9bcorp.com'), subject: "Evictions File ID: #{@eviction_file.id}",
+         reply_to: 'info@arnallfamilyfoundation.org')
   end
 end

--- a/app/models/eviction_letter.rb
+++ b/app/models/eviction_letter.rb
@@ -26,9 +26,9 @@ class EvictionLetter < ApplicationRecord
 
     finish = date - 1.day
     start = if date.monday?
-              date - 4.days
-            else # for Wednesday and Friday
               date - 3.days
+            else # for Wednesday and Friday
+              date - 2.days
             end
 
     { start: start, finish: finish }

--- a/app/models/eviction_letter.rb
+++ b/app/models/eviction_letter.rb
@@ -21,17 +21,27 @@ class EvictionLetter < ApplicationRecord
                                .where(docket_events: { event_on: 30.days.ago..Date.today })
                            }
 
-  def self.file_pull(date)
+  def self.calculate_dates(date)
     raise 'Invalid date: mailer only happens on M, W, F' unless date.monday? || date.wednesday? || date.friday?
 
     finish = date - 1.day
-    if date.monday?
-      start = date - 4.days
-    elsif date.wednesday? || date.friday?
-      start = date - 3.days
-    end
+    start = if date.monday?
+              date - 4.days
+            else # for Wednesday and Friday
+              date - 3.days
+            end
 
-    joins(docket_event_link: { docket_event: :court_case }).where(court_cases: { filed_on: start..finish })
+    { start: start, finish: finish }
+  end
+
+  # Method to perform the file pull operation using the calculated dates
+  def self.file_pull(date)
+    dates = calculate_dates(date) # Get start and finish dates
+    start = dates[:start]
+    finish = dates[:finish]
+
+    joins(docket_event_link: { docket_event: :court_case })
+      .where(court_cases: { filed_on: start..finish })
   end
 
   def full_name

--- a/app/services/eviction_file_generator.rb
+++ b/app/services/eviction_file_generator.rb
@@ -62,8 +62,19 @@ class EvictionFileGenerator
       eviction_letter.validation_zip_code,
       eviction_letter.docket_event_link.docket_event.court_case.case_number,
       eviction_letter.full_name,
-      eviction_letter.docket_event_link.docket_event.court_case.events.first&.event_at&.in_time_zone('Central Time (US & Canada)'),
+      scheduled_court_date(eviction_letter),
       eviction_letter.docket_event_link.docket_event.court_case.oscn_link
     ]
+  end
+
+  def scheduled_court_date(eviction_letter)
+    eviction_letter
+      .docket_event_link
+      .docket_event
+      .court_case
+      .events
+      .first
+      &.event_at
+      &.in_time_zone('Central Time (US & Canada)')
   end
 end

--- a/app/services/eviction_file_generator.rb
+++ b/app/services/eviction_file_generator.rb
@@ -62,7 +62,7 @@ class EvictionFileGenerator
       eviction_letter.validation_zip_code,
       eviction_letter.docket_event_link.docket_event.court_case.case_number,
       eviction_letter.full_name,
-      eviction_letter.docket_event_link.docket_event.court_case.events.first&.event_at,
+      eviction_letter.docket_event_link.docket_event.court_case.events.first&.event_at&.in_time_zone('Central Time (US & Canada)'),
       eviction_letter.docket_event_link.docket_event.court_case.oscn_link
     ]
   end

--- a/app/services/eviction_file_generator.rb
+++ b/app/services/eviction_file_generator.rb
@@ -37,7 +37,8 @@ class EvictionFileGenerator
     # Save to EvictionFile
     eviction_file = EvictionFile.new
     eviction_file.generated_at = DateTime.current
-    eviction_file.file.attach(io: File.open(temp_file.path), filename: "eviction_letters_#{date.strftime('%Y-%m-%d')}.csv")
+    eviction_file.file.attach(io: File.open(temp_file.path),
+                              filename: "eviction_letters_#{date.strftime('%Y-%m-%d')}.csv")
     # Mail to quickprint
     eviction_file.save
     EvictionsMailer.file_email(eviction_file.id, date_range).deliver_now

--- a/app/services/eviction_file_generator.rb
+++ b/app/services/eviction_file_generator.rb
@@ -37,7 +37,7 @@ class EvictionFileGenerator
     # Save to EvictionFile
     eviction_file = EvictionFile.new
     eviction_file.generated_at = DateTime.current
-    eviction_file.file.attach(io: File.open(temp_file.path), filename: "eviction_letters_#{Time.zone.now.to_date}.csv")
+    eviction_file.file.attach(io: File.open(temp_file.path), filename: "eviction_letters_#{date.strftime('%Y-%m-%d')}.csv")
     # Mail to quickprint
     eviction_file.save
     EvictionsMailer.file_email(eviction_file.id, date_range).deliver_now

--- a/app/views/evictions_mailer/file_email.html.erb
+++ b/app/views/evictions_mailer/file_email.html.erb
@@ -1,5 +1,10 @@
 <h2>Evictions File (ID: <%= @eviction_file.id %>)</h2>
-<h5>Date: <%= Time.zone.now.strftime('%m/%d/%Y') %></h5>
+<h5>Generated At: <%= @generated_at.strftime('%m/%d/%Y %l:%M %p') %></h5>
+<h5>Days Included in File: <%= @start.strftime('%m/%d/%Y') %> - <%= @finish.strftime('%m/%d/%Y') %></h5>
 <p>
   The attached file contains the latest evictions data
+</p>
+
+<p>
+  Warning: The email evictions@mail.arnallfamilyfoundation.org is not monitored, please do not reply to it. If you have any questions, please contact info@arnallfamilyfoundation.org
 </p>

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,5 +38,6 @@ module BackendTemplate
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+    config.time_zone = 'Central Time (US & Canada)'
   end
 end

--- a/spec/mailers/evictions_mailer_spec.rb
+++ b/spec/mailers/evictions_mailer_spec.rb
@@ -2,29 +2,36 @@ require 'rails_helper'
 
 RSpec.describe EvictionsMailer, type: :mailer do
   describe 'file_email' do
-    let(:eviction_file) { create(:eviction_file, :with_file) }
+    let(:eviction_file) { create(:eviction_file, :with_file, generated_at: Date.new(2024, 3, 13)) }
+    let(:date_range) { EvictionLetter.calculate_dates(Date.current) }
     let(:eviction_file_no_file) { create(:eviction_file) }
 
     context 'when the file exists' do
       it 'attaches the file' do
-        mail = described_class.file_email(eviction_file.id)
+        travel_to Date.new(2024, 3, 13) do
+          mail = described_class.file_email(eviction_file.id, date_range)
 
-        expect(mail.subject).to eq("Evictions File ID: #{eviction_file.id}")
-        expect(mail.attachments[eviction_file.file.filename.to_s]).to be_present
+          expect(mail.subject).to eq("Evictions File ID: #{eviction_file.id}")
+          expect(mail.attachments[eviction_file.file.filename.to_s]).to be_present
+        end
       end
 
       it 'sends the email' do
-        mail = described_class.file_email(eviction_file.id)
+        travel_to Date.new(2024, 3, 13) do
+          mail = described_class.file_email(eviction_file.id, date_range)
 
-        expect { mail.deliver_now }.to change { ActionMailer::Base.deliveries.count }.by(1)
+          expect { mail.deliver_now }.to change { ActionMailer::Base.deliveries.count }.by(1)
+        end
       end
     end
 
     context 'when the file does not exist' do
       it 'does not send an email' do
-        mail = described_class.file_email(eviction_file_no_file.id)
+        travel_to Date.new(2024, 3, 13) do
+          mail = described_class.file_email(eviction_file_no_file.id, date_range)
 
-        expect { mail.deliver_now }.to raise_error('No file attached to the EvictionFile')
+          expect { mail.deliver_now }.to raise_error('No file attached to the EvictionFile')
+        end
       end
     end
   end

--- a/spec/models/eviction_letter_spec.rb
+++ b/spec/models/eviction_letter_spec.rb
@@ -61,6 +61,42 @@ RSpec.describe EvictionLetter, type: :model do
       end
     end
 
+    describe '.calculate_dates' do
+      context 'when monday' do
+        it 'returns the start and finish dates' do
+          travel_to Date.new(2024, 2, 19) do
+            expect(EvictionLetter.calculate_dates(Date.today)).to eq({ start: 4.days.ago, finish: 1.day.ago })
+          end
+        end
+      end
+
+      context 'when wednesday' do
+        it 'returns the start and finish dates' do
+          travel_to Date.new(2024, 2, 21) do
+            expect(EvictionLetter.calculate_dates(Date.today)).to eq({ start: 3.days.ago, finish: 1.day.ago })
+          end
+        end
+      end
+
+      context 'when friday' do
+        it 'returns the start and finish dates' do
+          travel_to Date.new(2024, 2, 23) do
+            expect(EvictionLetter.calculate_dates(Date.today)).to eq({ start: 3.days.ago, finish: 1.day.ago })
+          end
+        end
+      end
+
+      context 'when tuesday, thursday, saturday, sunday' do
+        it 'raises an error' do
+          travel_to Date.new(2024, 2, 20) do
+            expect do
+              EvictionLetter.calculate_dates(Date.today)
+            end.to raise_error('Invalid date: mailer only happens on M, W, F')
+          end
+        end
+      end
+    end
+
     describe '.file_pull' do
       context 'when monday' do
         it 'returns letters from F, Sa, Su on Monday' do

--- a/spec/models/eviction_letter_spec.rb
+++ b/spec/models/eviction_letter_spec.rb
@@ -65,7 +65,13 @@ RSpec.describe EvictionLetter, type: :model do
       context 'when monday' do
         it 'returns the start and finish dates' do
           travel_to Date.new(2024, 2, 19) do
-            expect(EvictionLetter.calculate_dates(Date.today)).to eq({ start: 4.days.ago, finish: 1.day.ago })
+            expected_start = Date.new(2024, 2, 16)
+            expected_finish = Date.new(2024, 2, 18)
+
+            result = described_class.calculate_dates(Date.today)
+
+            expect(result[:start]).to eq expected_start
+            expect(result[:finish]).to eq expected_finish
           end
         end
       end
@@ -73,7 +79,13 @@ RSpec.describe EvictionLetter, type: :model do
       context 'when wednesday' do
         it 'returns the start and finish dates' do
           travel_to Date.new(2024, 2, 21) do
-            expect(EvictionLetter.calculate_dates(Date.today)).to eq({ start: 3.days.ago, finish: 1.day.ago })
+            expected_start = Date.new(2024, 2, 19)
+            expected_finish = Date.new(2024, 2, 20)
+
+            result = described_class.calculate_dates(Date.today)
+
+            expect(result[:start]).to eq expected_start
+            expect(result[:finish]).to eq expected_finish
           end
         end
       end
@@ -81,7 +93,13 @@ RSpec.describe EvictionLetter, type: :model do
       context 'when friday' do
         it 'returns the start and finish dates' do
           travel_to Date.new(2024, 2, 23) do
-            expect(EvictionLetter.calculate_dates(Date.today)).to eq({ start: 3.days.ago, finish: 1.day.ago })
+            expected_start = Date.new(2024, 2, 21)
+            expected_finish = Date.new(2024, 2, 22)
+
+            result = described_class.calculate_dates(Date.today)
+
+            expect(result[:start]).to eq expected_start
+            expect(result[:finish]).to eq expected_finish
           end
         end
       end


### PR DESCRIPTION
# Description

Adds the following adjustments to the evictions mailer:

- Adds Date range for what days are included in the file
- Sets the `reply to` to info email
- Adds warning to let receiver know that `evictions@` email is not monitored
- Ensures that file generates central time zone for scheduled appearance datetime