### PR TITLE
Force quotes and remove timestamp extras

### DIFF
--- a/app/services/eviction_file_generator.rb
+++ b/app/services/eviction_file_generator.rb
@@ -15,7 +15,7 @@ class EvictionFileGenerator
   end
 
   def generate
-    csv_string = CSV.generate do |csv|
+    csv_string = CSV.generate(force_quotes: true) do |csv|
       csv << add_headers
 
       eviction_letters.each do |eviction_letter|
@@ -77,5 +77,6 @@ class EvictionFileGenerator
       .first
       &.event_at
       &.in_time_zone('Central Time (US & Canada)')
+      &.strftime('%m/%d/%Y %I:%M %p')
   end
 end


### PR DESCRIPTION
# Description

Adds quotes to the CSV export. Removes the `-0500` timestamp offset indicating timezone