### PR TITLE
SOS Performance Fixes

### DIFF
--- a/app/services/importers/ok_sos/agents.rb
+++ b/app/services/importers/ok_sos/agents.rb
@@ -16,7 +16,7 @@ module Importers
           sos_ra_flag: data['sos_ra_flag'],
           entity_id: ::OkSos::Entity.find_by(filing_number: data['filing_number'])&.id,
           entity_address_id: ::OkSos::EntityAddress.find_by(address_id: data['address_id'])&.id,
-          suffix_id: get_cached(::OkSos::Suffix, :suffix_id, data['agent_suffix_id'])&.id
+          suffix_id: get_cached(::OkSos::Suffix, :suffix_id, data['agent_suffix_id'])
         }
       end
 

--- a/app/services/importers/ok_sos/agents.rb
+++ b/app/services/importers/ok_sos/agents.rb
@@ -14,9 +14,9 @@ module Importers
           inactive_date: parse_date(data['inactive_date']),
           normalized_name: data['normalized_name'],
           sos_ra_flag: data['sos_ra_flag'],
-          entity_id: get_cached(::OkSos::Entity, :filing_number, data['filing_number']),
-          entity_address_id: get_cached(::OkSos::EntityAddress, :address_id, data['address_id']),
-          suffix_id: get_cached(::OkSos::Suffix, :suffix_id, data['agent_suffix_id'])
+          entity_id: lookup_cached_id(::OkSos::Entity, :filing_number, data['filing_number']),
+          entity_address_id: lookup_cached_id(::OkSos::EntityAddress, :address_id, data['address_id']),
+          suffix_id: lookup_cached_id(::OkSos::Suffix, :suffix_id, data['agent_suffix_id'])
         }
       end
 

--- a/app/services/importers/ok_sos/agents.rb
+++ b/app/services/importers/ok_sos/agents.rb
@@ -14,8 +14,8 @@ module Importers
           inactive_date: parse_date(data['inactive_date']),
           normalized_name: data['normalized_name'],
           sos_ra_flag: data['sos_ra_flag'],
-          entity_id: ::OkSos::Entity.find_by(filing_number: data['filing_number'])&.id,
-          entity_address_id: ::OkSos::EntityAddress.find_by(address_id: data['address_id'])&.id,
+          entity_id: get_cached(::OkSos::Entity, :filing_number, data['filing_number']),
+          entity_address_id: get_cached(::OkSos::EntityAddress, :address_id, data['address_id']),
           suffix_id: get_cached(::OkSos::Suffix, :suffix_id, data['agent_suffix_id'])
         }
       end

--- a/app/services/importers/ok_sos/associated_entities.rb
+++ b/app/services/importers/ok_sos/associated_entities.rb
@@ -15,9 +15,9 @@ module Importers
           inactive_date: parse_date(data['inactive_date']),
           jurisdiction_state: data['jurisdiction_state'],
           jurisdiction_country: data['jurisdiction_country'],
-          capacity_id: get_cached(::OkSos::Capacity, :capacity_id, data['capacity_id'])&.id,
+          capacity_id: get_cached(::OkSos::Capacity, :capacity_id, data['capacity_id']),
           entity_id: ::OkSos::Entity.find_by(filing_number: data['filing_number'])&.id,
-          corp_type_id: get_cached(::OkSos::CorpType, :corp_type_id, data['associated_entity_corp_type_id'])&.id
+          corp_type_id: get_cached(::OkSos::CorpType, :corp_type_id, data['associated_entity_corp_type_id'])
         }
       end
 

--- a/app/services/importers/ok_sos/associated_entities.rb
+++ b/app/services/importers/ok_sos/associated_entities.rb
@@ -16,7 +16,7 @@ module Importers
           jurisdiction_state: data['jurisdiction_state'],
           jurisdiction_country: data['jurisdiction_country'],
           capacity_id: get_cached(::OkSos::Capacity, :capacity_id, data['capacity_id']),
-          entity_id: ::OkSos::Entity.find_by(filing_number: data['filing_number'])&.id,
+          entity_id: get_cached(::OkSos::Entity, :filing_number, data['filing_number']),
           corp_type_id: get_cached(::OkSos::CorpType, :corp_type_id, data['associated_entity_corp_type_id'])
         }
       end

--- a/app/services/importers/ok_sos/associated_entities.rb
+++ b/app/services/importers/ok_sos/associated_entities.rb
@@ -15,9 +15,9 @@ module Importers
           inactive_date: parse_date(data['inactive_date']),
           jurisdiction_state: data['jurisdiction_state'],
           jurisdiction_country: data['jurisdiction_country'],
-          capacity_id: get_cached(::OkSos::Capacity, :capacity_id, data['capacity_id']),
-          entity_id: get_cached(::OkSos::Entity, :filing_number, data['filing_number']),
-          corp_type_id: get_cached(::OkSos::CorpType, :corp_type_id, data['associated_entity_corp_type_id'])
+          capacity_id: lookup_cached_id(::OkSos::Capacity, :capacity_id, data['capacity_id']),
+          entity_id: lookup_cached_id(::OkSos::Entity, :filing_number, data['filing_number']),
+          corp_type_id: lookup_cached_id(::OkSos::CorpType, :corp_type_id, data['associated_entity_corp_type_id'])
         }
       end
 

--- a/app/services/importers/ok_sos/base_importer.rb
+++ b/app/services/importers/ok_sos/base_importer.rb
@@ -9,7 +9,7 @@ module Importers
 
       def initialize(file_path)
         @file_path = file_path
-        @@model_cache = ActiveSupport::HashWithIndifferentAccess.new({})
+        @@id_cache = ActiveSupport::HashWithIndifferentAccess.new({})
         super()
       end
 
@@ -85,15 +85,15 @@ module Importers
         end
       end
 
-      def model_cache(klass, key)
+      def id_cache(klass, key)
         klass_key = klass.to_s
-        return @@model_cache[klass_key] if @@model_cache[klass_key]
+        return @@id_cache[klass_key] if @@id_cache[klass_key]
 
-        @@model_cache[klass_key] = klass.pluck(key, :id).to_h { |x| [x[0].to_s, x[1]] }
-        @@model_cache[klass_key]
+        @@id_cache[klass_key] = klass.pluck(key, :id).to_h { |x| [x[0].to_s, x[1]] }
+        @@id_cache[klass_key]
       end
 
-      def get_cached(klass, key, value, create: false)
+      def lookup_cached_id(klass, key, value, create: false)
         return nil unless value.present? && value != '0'
 
         return model_cache(klass, key)[value.to_s] if model_cache(klass, key)[value.to_s]
@@ -101,7 +101,7 @@ module Importers
         raise ActiveRecord::RecordNotFound unless create
 
         new_model = klass.create!(key => value)
-        @@model_cache[klass.to_s][value.to_s] = new_model.id
+        @@id_cache[klass.to_s][value.to_s] = new_model.id
         new_model.id
       end
 

--- a/app/services/importers/ok_sos/base_importer.rb
+++ b/app/services/importers/ok_sos/base_importer.rb
@@ -96,7 +96,7 @@ module Importers
       def lookup_cached_id(klass, key, value, create: false)
         return nil unless value.present? && value != '0'
 
-        return model_cache(klass, key)[value.to_s] if model_cache(klass, key)[value.to_s]
+        return id_cache(klass, key)[value.to_s] if id_cache(klass, key)[value.to_s]
 
         raise ActiveRecord::RecordNotFound unless create
 

--- a/app/services/importers/ok_sos/base_importer.rb
+++ b/app/services/importers/ok_sos/base_importer.rb
@@ -32,7 +32,8 @@ module Importers
           rescue StandardError => e
             error_rows << { row: row, e: e }
           end
-          if ((rows + error_rows).count % BATCH_SIZE).zero? || rows.count == row_count
+          total_rows = (rows + error_rows).count
+          if (total_rows % BATCH_SIZE).zero? || total_rows == row_count
             rows = check_and_fix_duplicates(rows)
             bar&.increment!
             import_class.upsert_all(rows, unique_by: unique_by)

--- a/app/services/importers/ok_sos/base_importer.rb
+++ b/app/services/importers/ok_sos/base_importer.rb
@@ -34,9 +34,14 @@ module Importers
           end
           total_rows = (rows + error_rows).count
           if (total_rows % BATCH_SIZE).zero? || total_rows == row_count
+            print_errors(error_rows) if error_rows.present?
             rows = check_and_fix_duplicates(rows)
             bar&.increment!
-            import_class.upsert_all(rows, unique_by: unique_by)
+            if rows.blank?
+              puts "empty list of rows "
+            else
+              import_class.upsert_all(rows, unique_by: unique_by)
+            end
             rows = []
             error_rows = []
           end

--- a/app/services/importers/ok_sos/base_importer.rb
+++ b/app/services/importers/ok_sos/base_importer.rb
@@ -9,7 +9,7 @@ module Importers
 
       def initialize(file_path)
         @file_path = file_path
-        @model_cache = ActiveSupport::HashWithIndifferentAccess.new({})
+        @@model_cache = ActiveSupport::HashWithIndifferentAccess.new({})
         super()
       end
 
@@ -85,11 +85,11 @@ module Importers
       end
 
       def model_cache(klass, key)
-        cache_key = klass.to_s
-        return @model_cache[cache_key] if @model_cache[cache_key]
+        klass_key = klass.to_s
+        return @@model_cache[klass_key] if @@model_cache[klass_key]
 
-        @model_cache[cache_key] = klass.all.to_h { |x| [x[key].to_s, x] }
-        @model_cache[cache_key]
+        @@model_cache[klass_key] = klass.pluck(key, :id).to_h { |x| [x[0].to_s, x[1]] }
+        @@model_cache[klass_key]
       end
 
       def get_cached(klass, key, value, create: false)
@@ -100,8 +100,8 @@ module Importers
         raise ActiveRecord::RecordNotFound unless create
 
         new_model = klass.create!(key => value)
-        @model_cache[klass.to_s][value.to_s] = new_model
-        new_model
+        @@model_cache[klass.to_s][value.to_s] = new_model.id
+        new_model.id
       end
 
       def ignore_duplicates

--- a/app/services/importers/ok_sos/base_importer.rb
+++ b/app/services/importers/ok_sos/base_importer.rb
@@ -103,7 +103,7 @@ module Importers
 
         return id_cache(klass, key)[value.to_s] if id_cache(klass, key)[value.to_s]
 
-        raise ActiveRecord::RecordNotFound unless create
+        return nil unless create
 
         new_model = klass.create!(key => value)
         @@id_cache[klass.to_s][value.to_s] = new_model.id

--- a/app/services/importers/ok_sos/corp_filings.rb
+++ b/app/services/importers/ok_sos/corp_filings.rb
@@ -12,8 +12,8 @@ module Importers
           effective_date: parse_date(data['effective_date']),
           effective_cond_flag: data['effective_cond_flag'],
           inactive_date: parse_date(data['inactive_date']),
-          filing_type_id: get_cached(::OkSos::FilingType, :filing_type_id, data['filing_type_id']),
-          entity_id: get_cached(::OkSos::Entity, :filing_number, data['filing_number'])
+          filing_type_id: lookup_cached_id(::OkSos::FilingType, :filing_type_id, data['filing_type_id']),
+          entity_id: lookup_cached_id(::OkSos::Entity, :filing_number, data['filing_number'])
         }
       end
 

--- a/app/services/importers/ok_sos/corp_filings.rb
+++ b/app/services/importers/ok_sos/corp_filings.rb
@@ -12,7 +12,7 @@ module Importers
           effective_date: parse_date(data['effective_date']),
           effective_cond_flag: data['effective_cond_flag'],
           inactive_date: parse_date(data['inactive_date']),
-          filing_type_id: get_cached(::OkSos::FilingType, :filing_type_id, data['filing_type_id'])&.id,
+          filing_type_id: get_cached(::OkSos::FilingType, :filing_type_id, data['filing_type_id']),
           entity_id: ::OkSos::Entity.find_by(filing_number: data['filing_number'])&.id
         }
       end

--- a/app/services/importers/ok_sos/corp_filings.rb
+++ b/app/services/importers/ok_sos/corp_filings.rb
@@ -13,7 +13,7 @@ module Importers
           effective_cond_flag: data['effective_cond_flag'],
           inactive_date: parse_date(data['inactive_date']),
           filing_type_id: get_cached(::OkSos::FilingType, :filing_type_id, data['filing_type_id']),
-          entity_id: ::OkSos::Entity.find_by(filing_number: data['filing_number'])&.id
+          entity_id: get_cached(::OkSos::Entity, :filing_number, data['filing_number'])
         }
       end
 

--- a/app/services/importers/ok_sos/entities.rb
+++ b/app/services/importers/ok_sos/entities.rb
@@ -26,7 +26,7 @@ module Importers
           otc_suspension_flag: data['otc_suspension_flag'],
           consent_name_flag: data['consent_name_flag'],
           corp_type_id: get_cached(::OkSos::CorpType, :corp_type_id, data['corp_type_id']),
-          entity_address_id: data['address_id'] ? ::OkSos::EntityAddress.find_by(address_id: data['address_id'])&.id : nil
+          entity_address_id: data['address_id'] ? get_cached(::OkSos::EntityAddress, :address_id, data['address_id']) : nil
         }
       end
 

--- a/app/services/importers/ok_sos/entities.rb
+++ b/app/services/importers/ok_sos/entities.rb
@@ -25,8 +25,8 @@ module Importers
           telno: data['telno'],
           otc_suspension_flag: data['otc_suspension_flag'],
           consent_name_flag: data['consent_name_flag'],
-          corp_type_id: get_cached(::OkSos::CorpType, :corp_type_id, data['corp_type_id']),
-          entity_address_id: data['address_id'] ? get_cached(::OkSos::EntityAddress, :address_id, data['address_id']) : nil
+          corp_type_id: lookup_cached_id(::OkSos::CorpType, :corp_type_id, data['corp_type_id']),
+          entity_address_id: data['address_id'] ? lookup_cached_id(::OkSos::EntityAddress, :address_id, data['address_id']) : nil
         }
       end
 

--- a/app/services/importers/ok_sos/entities.rb
+++ b/app/services/importers/ok_sos/entities.rb
@@ -25,7 +25,7 @@ module Importers
           telno: data['telno'],
           otc_suspension_flag: data['otc_suspension_flag'],
           consent_name_flag: data['consent_name_flag'],
-          corp_type_id: get_cached(::OkSos::CorpType, :corp_type_id, data['corp_type_id'])&.id,
+          corp_type_id: get_cached(::OkSos::CorpType, :corp_type_id, data['corp_type_id']),
           entity_address_id: data['address_id'] ? ::OkSos::EntityAddress.find_by(address_id: data['address_id'])&.id : nil
         }
       end

--- a/app/services/importers/ok_sos/entity_addresses.rb
+++ b/app/services/importers/ok_sos/entity_addresses.rb
@@ -11,7 +11,7 @@ module Importers
           zip_string: data['zip_code'],
           zip_extension: data['zip_extension'],
           country: data['county'],
-          zip_code_id: get_cached(::ZipCode, :name, data['zip_code'])
+          zip_code_id: lookup_cached_id(::ZipCode, :name, data['zip_code'])
         }
       end
 

--- a/app/services/importers/ok_sos/entity_addresses.rb
+++ b/app/services/importers/ok_sos/entity_addresses.rb
@@ -11,7 +11,7 @@ module Importers
           zip_string: data['zip_code'],
           zip_extension: data['zip_extension'],
           country: data['county'],
-          zip_code_id: get_cached(::ZipCode, :name, data['zip_code'], create: true)
+          zip_code_id: get_cached(::ZipCode, :name, data['zip_code'])
         }
       end
 

--- a/app/services/importers/ok_sos/entity_addresses.rb
+++ b/app/services/importers/ok_sos/entity_addresses.rb
@@ -11,7 +11,7 @@ module Importers
           zip_string: data['zip_code'],
           zip_extension: data['zip_extension'],
           country: data['county'],
-          zip_code_id: get_cached(::ZipCode, :name, data['zip_code'], create: true)&.id
+          zip_code_id: get_cached(::ZipCode, :name, data['zip_code'], create: true)
         }
       end
 

--- a/app/services/importers/ok_sos/names.rb
+++ b/app/services/importers/ok_sos/names.rb
@@ -16,8 +16,8 @@ module Importers
           search_id: data['search_id'],
           transfer_to: data['transfer_to'],
           received_from: data['received_from'],
-          name_type_id: get_cached(::OkSos::NameType, :name_type_id, data['name_type_id'])&.id,
-          name_status_id: get_cached(::OkSos::NameStatus, :name_status_id, data['name_status_id'])&.id,
+          name_type_id: get_cached(::OkSos::NameType, :name_type_id, data['name_type_id']),
+          name_status_id: get_cached(::OkSos::NameStatus, :name_status_id, data['name_status_id']),
           entity_id: data['filing_number'] ? ::OkSos::Entity.find_by(filing_number: data['filing_number'])&.id : nil
         }
       end

--- a/app/services/importers/ok_sos/names.rb
+++ b/app/services/importers/ok_sos/names.rb
@@ -18,7 +18,10 @@ module Importers
           received_from: data['received_from'],
           name_type_id: lookup_cached_id(::OkSos::NameType, :name_type_id, data['name_type_id']),
           name_status_id: lookup_cached_id(::OkSos::NameStatus, :name_status_id, data['name_status_id']),
-          entity_id: data['filing_number'] ? lookup_cached_id(::OkSos::Entity, :filing_number, data['filing_number']) : nil
+          entity_id: if data['filing_number']
+                       lookup_cached_id(::OkSos::Entity, :filing_number,
+                                        data['filing_number'])
+                     end
         }
       end
 

--- a/app/services/importers/ok_sos/names.rb
+++ b/app/services/importers/ok_sos/names.rb
@@ -16,9 +16,9 @@ module Importers
           search_id: data['search_id'],
           transfer_to: data['transfer_to'],
           received_from: data['received_from'],
-          name_type_id: get_cached(::OkSos::NameType, :name_type_id, data['name_type_id']),
-          name_status_id: get_cached(::OkSos::NameStatus, :name_status_id, data['name_status_id']),
-          entity_id: data['filing_number'] ? get_cached(::OkSos::Entity, :filing_number, data['filing_number']) : nil
+          name_type_id: lookup_cached_id(::OkSos::NameType, :name_type_id, data['name_type_id']),
+          name_status_id: lookup_cached_id(::OkSos::NameStatus, :name_status_id, data['name_status_id']),
+          entity_id: data['filing_number'] ? lookup_cached_id(::OkSos::Entity, :filing_number, data['filing_number']) : nil
         }
       end
 

--- a/app/services/importers/ok_sos/names.rb
+++ b/app/services/importers/ok_sos/names.rb
@@ -18,7 +18,7 @@ module Importers
           received_from: data['received_from'],
           name_type_id: get_cached(::OkSos::NameType, :name_type_id, data['name_type_id']),
           name_status_id: get_cached(::OkSos::NameStatus, :name_status_id, data['name_status_id']),
-          entity_id: data['filing_number'] ? ::OkSos::Entity.find_by(filing_number: data['filing_number'])&.id : nil
+          entity_id: data['filing_number'] ? get_cached(::OkSos::Entity, :filing_number, data['filing_number']) : nil
         }
       end
 

--- a/app/services/importers/ok_sos/officers.rb
+++ b/app/services/importers/ok_sos/officers.rb
@@ -18,7 +18,7 @@ module Importers
           normalized_name: data['normalized_name'],
           entity_address_id: ::OkSos::EntityAddress.find_by(address_id: data['address_id'])&.id,
           entity_id: ::OkSos::Entity.find_by(filing_number: data['filing_number'])&.id,
-          suffix_id: get_cached(::OkSos::Suffix, :suffix_id, data['agent_suffix_id'])&.id
+          suffix_id: get_cached(::OkSos::Suffix, :suffix_id, data['agent_suffix_id'])
         }
       end
 

--- a/app/services/importers/ok_sos/officers.rb
+++ b/app/services/importers/ok_sos/officers.rb
@@ -16,9 +16,9 @@ module Importers
           inactive_date: parse_date(data['inactive_date']),
           last_modified_date: parse_date(data['last_modified_date']),
           normalized_name: data['normalized_name'],
-          entity_address_id: get_cached(::OkSos::EntityAddress, :address_id, data['address_id']),
-          entity_id: get_cached(::OkSos::Entity, :filing_number, data['filing_number']),
-          suffix_id: get_cached(::OkSos::Suffix, :suffix_id, data['agent_suffix_id'])
+          entity_address_id: lookup_cached_id(::OkSos::EntityAddress, :address_id, data['address_id']),
+          entity_id: lookup_cached_id(::OkSos::Entity, :filing_number, data['filing_number']),
+          suffix_id: lookup_cached_id(::OkSos::Suffix, :suffix_id, data['agent_suffix_id'])
         }
       end
 

--- a/app/services/importers/ok_sos/officers.rb
+++ b/app/services/importers/ok_sos/officers.rb
@@ -16,8 +16,8 @@ module Importers
           inactive_date: parse_date(data['inactive_date']),
           last_modified_date: parse_date(data['last_modified_date']),
           normalized_name: data['normalized_name'],
-          entity_address_id: ::OkSos::EntityAddress.find_by(address_id: data['address_id'])&.id,
-          entity_id: ::OkSos::Entity.find_by(filing_number: data['filing_number'])&.id,
+          entity_address_id: get_cached(::OkSos::EntityAddress, :address_id, data['address_id']),
+          entity_id: get_cached(::OkSos::Entity, :filing_number, data['filing_number']),
           suffix_id: get_cached(::OkSos::Suffix, :suffix_id, data['agent_suffix_id'])
         }
       end

--- a/app/services/importers/ok_sos/split_files.rb
+++ b/app/services/importers/ok_sos/split_files.rb
@@ -38,6 +38,8 @@ module Importers
       end
 
       def import_files
+        ::Importers::OkSos::ZipCodes.perform(@csvs["entity_addresses"].path)
+
         [
           :audit_logs,
           :capacities,
@@ -69,7 +71,7 @@ module Importers
         file_name = ''
         merged_row = '' # multiple rows may need to get merged if there is a \r or \n in a string column
         line_count = `wc -l "#{@combined_file.path}"`.strip.split[0].to_i
-        puts "Start time: #{Time.now}. Splitting csv. Combined csv line count is: #{line_count}"
+        puts "Splitting csv into separate files. Combined csv line count is: #{line_count}. Start time: #{Time.now}."
         bar = ProgressBar.new(line_count)
         File.new(@combined_file.path).each do |row_string|
           bar.increment!
@@ -107,7 +109,7 @@ module Importers
       end
 
       def download_combined_csv
-        puts 'Downloading combined csv zip file from aws.'
+        puts 'Downloading combined csv zip file from aws. This may take a minute or so.'
         response = Bucket.new.get_object("ok_sos/#{combined_zip_name}")
         Zip::InputStream.open(response.body) do |io|
           io.get_next_entry

--- a/app/services/importers/ok_sos/stock_data.rb
+++ b/app/services/importers/ok_sos/stock_data.rb
@@ -9,7 +9,7 @@ module Importers
           stock_series: data['stock_series'],
           share_volume: data['share_volume'],
           par_value: data['par_value'],
-          entity_id: ::OkSos::Entity.find_by(filing_number: data['filing_number'])&.id,
+          entity_id: get_cached(::OkSos::Entity, :filing_number, data['filing_number']),
           stock_type_id: get_cached(::OkSos::StockType, :stock_type_id, data['stock_type_id'])
         }
       end

--- a/app/services/importers/ok_sos/stock_data.rb
+++ b/app/services/importers/ok_sos/stock_data.rb
@@ -10,7 +10,7 @@ module Importers
           share_volume: data['share_volume'],
           par_value: data['par_value'],
           entity_id: ::OkSos::Entity.find_by(filing_number: data['filing_number'])&.id,
-          stock_type_id: get_cached(::OkSos::StockType, :stock_type_id, data['stock_type_id'])&.id
+          stock_type_id: get_cached(::OkSos::StockType, :stock_type_id, data['stock_type_id'])
         }
       end
 

--- a/app/services/importers/ok_sos/stock_data.rb
+++ b/app/services/importers/ok_sos/stock_data.rb
@@ -9,8 +9,8 @@ module Importers
           stock_series: data['stock_series'],
           share_volume: data['share_volume'],
           par_value: data['par_value'],
-          entity_id: get_cached(::OkSos::Entity, :filing_number, data['filing_number']),
-          stock_type_id: get_cached(::OkSos::StockType, :stock_type_id, data['stock_type_id'])
+          entity_id: lookup_cached_id(::OkSos::Entity, :filing_number, data['filing_number']),
+          stock_type_id: lookup_cached_id(::OkSos::StockType, :stock_type_id, data['stock_type_id'])
         }
       end
 

--- a/app/services/importers/ok_sos/stock_infos.rb
+++ b/app/services/importers/ok_sos/stock_infos.rb
@@ -9,7 +9,7 @@ module Importers
           actual_amount_invested: data['actual_amt_invested'],
           pd_on_credit: data['pd_on_credit'],
           tot_auth_capital: data['tot_auth_capital'],
-          entity_id: get_cached(::OkSos::Entity, :filing_number, data['filing_number'])
+          entity_id: lookup_cached_id(::OkSos::Entity, :filing_number, data['filing_number'])
         }
       end
 

--- a/app/services/importers/ok_sos/stock_infos.rb
+++ b/app/services/importers/ok_sos/stock_infos.rb
@@ -9,7 +9,7 @@ module Importers
           actual_amount_invested: data['actual_amt_invested'],
           pd_on_credit: data['pd_on_credit'],
           tot_auth_capital: data['tot_auth_capital'],
-          entity_id: ::OkSos::Entity.find_by(filing_number: data['filing_number'])&.id
+          entity_id: get_cached(::OkSos::Entity, :filing_number, data['filing_number'])
         }
       end
 

--- a/app/services/importers/ok_sos/zip_codes.rb
+++ b/app/services/importers/ok_sos/zip_codes.rb
@@ -1,0 +1,23 @@
+module Importers
+  module OkSos
+    class ZipCodes < BaseImporter
+      def attributes(data)
+        {
+          name: data['zip_code']
+        }
+      end
+
+      def unique_by
+        [:name]
+      end
+
+      def import_class
+        ::ZipCode
+      end
+
+      def ignore_duplicates
+        true
+      end
+    end
+  end
+end

--- a/db/migrate/20240821163508_add_name_index_to_zip_code.rb
+++ b/db/migrate/20240821163508_add_name_index_to_zip_code.rb
@@ -1,0 +1,5 @@
+class AddNameIndexToZipCode < ActiveRecord::Migration[7.0]
+  def change
+    add_index :zip_codes, :name, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_07_10_130156) do
+ActiveRecord::Schema[7.0].define(version: 2024_08_21_163508) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "plpgsql"
@@ -1182,6 +1182,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_10_130156) do
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_zip_codes_on_name", unique: true
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/spec/services/importers/ok_sos/entity_addresses_spec.rb
+++ b/spec/services/importers/ok_sos/entity_addresses_spec.rb
@@ -4,6 +4,7 @@ require 'services/importers/ok_sos/shared_specs'
 RSpec.describe Importers::OkSos::EntityAddresses do
   it_behaves_like 'ok_sos_importer' do
     let(:sample_file) { 'spec/fixtures/importers/ok_sos/entity_addresses.csv' }
+    let!(:zip_code) { create(:zip_code, name: 73_103) }
     let(:record) { OkSos::EntityAddress.find_by!(address_id: 10) }
     let(:expected_attributes) do
       {
@@ -15,7 +16,7 @@ RSpec.describe Importers::OkSos::EntityAddresses do
         zip_string: '73103',
         zip_extension: nil,
         country: 'USA',
-        zip_code_id: ZipCode.find_by(name: 73_103).id
+        zip_code_id: zip_code.id
       }
     end
   end

--- a/spec/services/importers/ok_sos/zip_codes_spec.rb
+++ b/spec/services/importers/ok_sos/zip_codes_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+require 'services/importers/ok_sos/shared_specs'
+
+RSpec.describe Importers::OkSos::ZipCodes do
+  it_behaves_like 'ok_sos_importer' do
+    let(:sample_file) { 'spec/fixtures/importers/ok_sos/entity_addresses.csv' }
+    let(:record) { ZipCode.find_by(name: "73103") } # TODO: update this with real key?
+    let(:expected_attributes) do
+      {
+        name: "73103"
+      }
+    end
+  end
+end

--- a/spec/services/importers/ok_sos/zip_codes_spec.rb
+++ b/spec/services/importers/ok_sos/zip_codes_spec.rb
@@ -4,7 +4,7 @@ require 'services/importers/ok_sos/shared_specs'
 RSpec.describe Importers::OkSos::ZipCodes do
   it_behaves_like 'ok_sos_importer' do
     let(:sample_file) { 'spec/fixtures/importers/ok_sos/entity_addresses.csv' }
-    let(:record) { ZipCode.find_by(name: '73103') } # TODO: update this with real key?
+    let(:record) { ZipCode.find_by(name: '73103') }
     let(:expected_attributes) do
       {
         name: '73103'

--- a/spec/services/importers/ok_sos/zip_codes_spec.rb
+++ b/spec/services/importers/ok_sos/zip_codes_spec.rb
@@ -4,10 +4,10 @@ require 'services/importers/ok_sos/shared_specs'
 RSpec.describe Importers::OkSos::ZipCodes do
   it_behaves_like 'ok_sos_importer' do
     let(:sample_file) { 'spec/fixtures/importers/ok_sos/entity_addresses.csv' }
-    let(:record) { ZipCode.find_by(name: "73103") } # TODO: update this with real key?
+    let(:record) { ZipCode.find_by(name: '73103') } # TODO: update this with real key?
     let(:expected_attributes) do
       {
-        name: "73103"
+        name: '73103'
       }
     end
   end


### PR DESCRIPTION
# Summary

Cut the local runtime from 5+ hours to closer to two.
The changes may be more noticeable on the server as it has to go over the wire for the database.

# Changes

**1) Insert ZipCodes for addresses in bulk**
This was being done row by row and due to the large amount of zip codes was still taking some time

**2) Cache larger lookups in memory.** 
The variable containing the large lookup (1390000 records) seem to be pretty well optimized in memory but take a few minutes to load. 

Testing info:

  ```
irb(main):002:0> Time.now
=> 2024-08-21 18:53:31.129373628 +0000
irb(main):003:0> test = ::OkSos::Entity.pluck(:filing_number, :id).to_h
D, [2024-08-21T18:53:40.920200 #2] DEBUG -- :   OkSos::Entity Pluck (6723.8ms)  SELECT "ok_sos_entities"."filing_number", "ok_sos_entities"."id" FROM "ok_sos_entities"
=>                                                                                                                                     
{1912071632=>630019,                                                                                                                   
...                                                                                                                                    
irb(main):004:0> Time.now
=> 2024-08-21 18:56:45.623127182 +0000
  ```
 
  ```
  irb(main):007:0> ObjectSpace.memsize_of(test)
=> 67108960
irb(main):008:0> puts 'RAM USAGE: ' + `pmap #{Process.pid} | tail -1`[10,40].strip
RAM USAGE: 1345428K
  ```

Tested on performance-2xl dyno