### PR TITLE
Add view of all criminal counts

### DIFF
--- a/app/models/report_criminal_case.rb
+++ b/app/models/report_criminal_case.rb
@@ -1,0 +1,12 @@
+class ReportCriminalCase < ApplicationRecord
+  belongs_to :court_case
+  belongs_to :county
+
+  def self.refresh
+    Scenic.database.refresh_materialized_view(table_name, cascade: false)
+  end
+
+  def readonly?
+    true
+  end
+end

--- a/db/migrate/20241009131403_create_report_criminal_cases.rb
+++ b/db/migrate/20241009131403_create_report_criminal_cases.rb
@@ -1,0 +1,14 @@
+class CreateReportCriminalCases < ActiveRecord::Migration[7.0]
+  def change
+    create_view :report_criminal_cases, materialized: true
+
+    add_index :report_criminal_cases, :count_offense_on
+    add_index :report_criminal_cases, :count_code_as_filed
+    add_index :report_criminal_cases, :count_code_as_disposed
+    add_index :report_criminal_cases, :count_disposition_on
+    add_index :report_criminal_cases, :court_case_id
+    add_index :report_criminal_cases, :county_id
+    add_index :report_criminal_cases, :court_case_filed_on
+    add_index :report_criminal_cases, :court_case_closed_on
+  end
+end

--- a/db/views/report_criminal_cases_v01.sql
+++ b/db/views/report_criminal_cases_v01.sql
@@ -1,0 +1,27 @@
+SELECT
+  counts.id AS count_id,
+  counts.offense_on as count_offense_on,
+  counts.as_filed as count_as_filed,
+  filed_code.code as count_code_as_filed,
+  counts.filed_statute_violation as statute,
+  counts.disposition as count_as_disposed,
+  disposed_code.code as count_code_as_disposed,
+  counts.disposition_on as count_disposition_on,
+  pleas.name as plea,
+  verdicts.name as verdict,
+  court_cases.id AS court_case_id,
+  court_cases.county_id AS county_id,
+  court_cases.case_type_id AS case_type_id,
+  court_cases.case_number AS court_case_case_number,
+  court_cases.filed_on AS court_case_filed_on,
+  court_cases.closed_on AS court_case_closed_on
+FROM
+  counts
+  JOIN court_cases ON counts.court_case_id = court_cases.id
+  JOIN case_types ON court_cases.case_type_id = case_types.id
+  LEFT JOIN pleas ON counts.plea_id = pleas.id
+  LEFT JOIN verdicts ON counts.verdict_id = verdicts.id
+  LEFT JOIN count_codes filed_code ON counts.filed_statute_code_id = filed_code.id
+  LEFT JOIN count_codes disposed_code ON counts.disposed_statute_code_id = disposed_code.id
+WHERE
+  case_types.abbreviation IN('CF', 'CM', 'MI', 'CPC')

--- a/spec/models/report_criminal_case_spec.rb
+++ b/spec/models/report_criminal_case_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ReportCriminalCase, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/report_criminal_case_spec.rb
+++ b/spec/models/report_criminal_case_spec.rb
@@ -1,5 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe ReportCriminalCase, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'associations' do
+    it { should belong_to(:court_case) }
+    it { should belong_to(:county) }
+  end
 end


### PR DESCRIPTION
# Description

Adds the `report_criminal_cases` materialized view to the database with indexes on connecting table ids and dates/count codes that might be used as slicers on the PowerBI side of things