### PR TITLE
Prevent record cap from being hit on Ok2Explore

### DIFF
--- a/app/models/ok2_explore/death.rb
+++ b/app/models/ok2_explore/death.rb
@@ -1,5 +1,5 @@
 class Ok2Explore::Death < ApplicationRecord
-  belongs_to :county
+  belongs_to :county, optional: true
 
   validates :first_name, :last_name, :death_on, presence: true
   enum sex: [:male, :female]

--- a/app/services/importers/ok2_explore/death.rb
+++ b/app/services/importers/ok2_explore/death.rb
@@ -27,7 +27,7 @@ module Importers
           name = county_name.gsub(/(?<=[a-z])(?=[A-Z])/, ' ')
           County.find_by!(name: name).id
         else
-          County.find_by!(name: county_name).id
+          County.find_by(name: county_name)&.id
         end
       end
     end

--- a/app/services/importers/ok2_explore/scrape_job.rb
+++ b/app/services/importers/ok2_explore/scrape_job.rb
@@ -20,7 +20,6 @@ module Importers
           return nil
         end
 
-        log "Found #{death_records.count} scrape_jobs."
         import_death_records(death_records)
 
         scrape_job.update(is_success: true)
@@ -50,6 +49,7 @@ module Importers
       end
 
       def import_death_records(death_records)
+        log "Found #{death_records.count} for scrape job"
         failed_scrape_jobs = []
         death_records.each do |data|
           ::Importers::Ok2Explore::Death.perform(data)

--- a/app/services/importers/ok2_explore/scrape_job.rb
+++ b/app/services/importers/ok2_explore/scrape_job.rb
@@ -6,6 +6,7 @@ module Importers
       def initialize(scrape_job, bar: false)
         @scrape_job = scrape_job
         @bar = bar
+        super()
       end
 
       def perform

--- a/app/services/importers/ok2_explore/scrape_job.rb
+++ b/app/services/importers/ok2_explore/scrape_job.rb
@@ -13,12 +13,12 @@ module Importers
         log "Scraping: #{scrape_job.id}"
         begin
           death_records = ::Ok2explore::Scraper.new(**scraper_args).perform
-        rescue ::Selenium::WebDriver::Error::TimeoutError
-          log 'Timeout occurred, skipping for now.'
-          return nil
         rescue ::Ok2explore::Errors::TooManyResults
           create_smaller_jobs(scrape_job)
           return nil
+        rescue StandardError
+          log 'An error occurred, skipping for now.'
+          return false
         end
 
         begin

--- a/app/services/importers/ok2_explore/scrape_job.rb
+++ b/app/services/importers/ok2_explore/scrape_job.rb
@@ -32,7 +32,7 @@ module Importers
 
       def create_smaller_jobs(scrape_job)
         log 'Too many results. Fanning out to smaller jobs'
-        scrape_job.update(is_too_many_scrape_jobs: true)
+        scrape_job.update(is_too_many_records: true)
 
         ('a'..'z').to_a.each do |added_letter|
           ::Ok2Explore::ScrapeJob.create(

--- a/app/services/importers/ok2_explore/scrape_job.rb
+++ b/app/services/importers/ok2_explore/scrape_job.rb
@@ -1,0 +1,67 @@
+module Importers
+  module Ok2Explore
+    class ScrapeJob < ApplicationService
+      attr_reader :scrape_job, :bar
+
+      def initialize(scrape_job, bar = false)
+        @scrape_job = scrape_job
+        @bar = bar
+      end
+
+      def perform
+        log "Scraping: #{scrape_job.id}"
+        begin
+          death_records = ::Ok2explore::Scraper.new(**scraper_args).perform
+        rescue ::Selenium::WebDriver::Error::TimeoutError
+          log 'Timeout occurred, continuing'
+          return nil
+        rescue ::Ok2explore::Errors::TooManyResults
+          create_smaller_jobs(scrape_job)
+          return nil
+        end
+
+        log "Found #{death_records.count} scrape_jobs."
+        import_death_records(death_records)
+
+        scrape_job.update(is_success: true)
+      end
+
+      def create_smaller_jobs(scrape_job)
+        log 'Too many results. Fanning out to smaller jobs'
+        scrape_job.update(is_too_many_scrape_jobs: true)
+
+        ('a'..'z').to_a.each do |added_letter|
+          ::Ok2Explore::ScrapeJob.create(
+            year: scrape_job.year.to_s,
+            month: scrape_job.month.to_s,
+            first_name: scrape_job.first_name.to_s,
+            last_name: "#{scrape_job.last_name}#{added_letter}"
+          )
+        end
+      end
+
+      def scraper_args
+        {
+          year: scrape_job.year.to_s,
+          month: scrape_job.month.to_s,
+          first_name: "#{scrape_job.first_name}*",
+          last_name: "#{scrape_job.last_name}*"
+        }
+      end
+
+      def import_death_records(death_records)
+        failed_scrape_jobs = []
+        death_records.each do |data|
+          ::Importers::Ok2Explore::Death.perform(data)
+        rescue StandardError
+          failed_scrape_jobs << data
+        end
+        log "#{failed_scrape_jobs.count} failed scrape_jobs" unless failed_scrape_jobs.count.zero?
+      end
+
+      def log(message)
+        bar ? bar.puts(message) : puts(message)
+      end
+    end
+  end
+end

--- a/app/services/importers/ok2_explore/scrape_job.rb
+++ b/app/services/importers/ok2_explore/scrape_job.rb
@@ -16,8 +16,8 @@ module Importers
         rescue ::Ok2explore::Errors::TooManyResults
           create_smaller_jobs(scrape_job)
           return nil
-        rescue StandardError
-          log 'An error occurred, skipping for now.'
+        rescue StandardError => e
+          log "An error occurred #{e}, skipping for now."
           return false
         end
 

--- a/app/services/importers/ok2_explore/scrape_pending_jobs.rb
+++ b/app/services/importers/ok2_explore/scrape_pending_jobs.rb
@@ -21,7 +21,7 @@ module Importers
         @bar = ProgressBar.new(needs_scraping.count)
         needs_scraping.each do |record|
           bar.increment!
-          ScrapeJob.perform(record, bar)
+          ScrapeJob.perform(record, bar: bar)
         end
 
         bar.puts 'Run complete. Restarting to try for failed or newly generated records.'

--- a/app/services/importers/ok2_explore/scrape_pending_jobs.rb
+++ b/app/services/importers/ok2_explore/scrape_pending_jobs.rb
@@ -1,11 +1,10 @@
 module Importers
   module Ok2Explore
     class ScrapePendingJobs < ApplicationService
-      attr_reader :record_limit, :retry_attempts, :bar
+      attr_reader :record_limit, :bar
 
       def initialize(record_limit)
         @record_limit = record_limit
-        @retry_attempts = 0
         super()
       end
 
@@ -17,7 +16,6 @@ module Importers
           puts 'No records to scrape'
           return true
         end
-        raise 'Unable to complete processing of death records.' if retry_attempts > retry_limit
 
         @bar = ProgressBar.new(needs_scraping.count)
         needs_scraping.each do |record|
@@ -25,14 +23,7 @@ module Importers
           ScrapeJob.perform(record, bar: bar)
         end
 
-        bar.puts 'Run complete. Restarting to try for failed or newly generated records.'
-        bar.puts "Retry attempt was: #{@retry_attempts}"
-        @retry_attempts += 1
-        perform
-      end
-
-      def retry_limit
-        ENV.fetch('OK2EXPLORE_JOB_RETRIES', 5)
+        bar.puts 'Run complete.'
       end
     end
   end

--- a/app/services/importers/ok2_explore/scrape_pending_jobs.rb
+++ b/app/services/importers/ok2_explore/scrape_pending_jobs.rb
@@ -1,0 +1,38 @@
+module Importers
+  module Ok2Explore
+    class ScrapePendingJobs < ApplicationService
+      attr_reader :record_limit, :retry_attempts, :bar
+
+      def initialize(record_limit)
+        @record_limit = record_limit
+        @retry_attempts = 0
+      end
+
+      def perform
+        needs_scraping = ::Ok2Explore::ScrapeJob.where(is_success: false,
+                                                     is_too_many_records: false).sample(record_limit.to_i)
+
+        if needs_scraping.count.zero?
+          puts 'No records to scrape'
+          return true
+        end
+        raise 'Unable to complete processing of death records.' if retry_attempts > retry_limit
+
+        @bar = ProgressBar.new(needs_scraping.count)
+        needs_scraping.each do |record|
+          bar.increment!
+          ScrapeJob.perform(record, bar)
+        end
+
+        bar.puts 'Run complete. Restarting to try for failed or newly generated records.'
+        bar.puts "Retry attempt was: #{@retry_attempts}"
+        @retry_attempts += 1
+        perform
+      end
+
+      def retry_limit
+        ENV.fetch('OK2EXPLORE_JOB_RETRIES', 5)
+      end
+    end
+  end
+end

--- a/app/services/importers/ok2_explore/scrape_pending_jobs.rb
+++ b/app/services/importers/ok2_explore/scrape_pending_jobs.rb
@@ -6,11 +6,12 @@ module Importers
       def initialize(record_limit)
         @record_limit = record_limit
         @retry_attempts = 0
+        super()
       end
 
       def perform
         needs_scraping = ::Ok2Explore::ScrapeJob.where(is_success: false,
-                                                     is_too_many_records: false).sample(record_limit.to_i)
+                                                       is_too_many_records: false).sample(record_limit.to_i)
 
         if needs_scraping.count.zero?
           puts 'No records to scrape'

--- a/db/migrate/20250129224136_update_deaths_county_nullable.rb
+++ b/db/migrate/20250129224136_update_deaths_county_nullable.rb
@@ -1,0 +1,5 @@
+class UpdateDeathsCountyNullable < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :ok2_explore_deaths, :county_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_01_22_120742) do
+ActiveRecord::Schema[7.0].define(version: 2025_01_29_224136) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_trgm"
@@ -477,7 +477,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_01_22_120742) do
     t.string "first_name", null: false
     t.string "middle_name"
     t.integer "sex", null: false
-    t.bigint "county_id", null: false
+    t.bigint "county_id"
     t.datetime "death_on", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/lib/tasks/deaths.rake
+++ b/lib/tasks/deaths.rake
@@ -17,47 +17,21 @@ namespace :scrape do
   end
 
   desc 'Scrape death records'
-  task :death_records, [:record_count] => [:environment] do |_t, args|
-    needs_scraping = Ok2Explore::ScrapeJob.where(is_success: false,
-                                                 is_too_many_records: false).sample(args.record_count.to_i)
-    needs_scraping.each do |record|
-      puts "Scraping: #{record.id}"
-      args = {
-        year: record.year.to_s,
-        month: record.month.to_s,
-        first_name: "#{record.first_name}*",
-        last_name: "#{record.last_name}*"
-      }
-      begin
-        records = Ok2explore::Scraper.new(**args).perform
-      rescue Ok2explore::Errors::TooManyResults
-        puts 'Too many results, skipping.'
-        record.update(is_too_many_records: true)
-        records = nil
-      end
-      next if records.nil?
-
-      puts "Found #{records.count} records."
-      records.each do |data|
-        ::Importers::Ok2Explore::Death.perform(data)
-      end
-      record.update(is_success: true)
-    end
+  task :death_records, [:record_limit] => [:environment] do |_t, args|
+    ::Importers::Ok2Explore::ScrapePendingJobs.perform(args.record_limit)
   end
 
   desc 'Populate desired scrapes for deaths'
-  task jobs: [:environment] do
-    (1980..2018).to_a.each do |year|
-      (1..12).to_a.each do |month|
-        ('a'..'z').to_a.each do |first_letter|
-          ('a'..'z').to_a.each do |last_letter|
-            Ok2Explore::ScrapeJob.create(
-              year: year,
-              month: month,
-              first_name: first_letter,
-              last_name: last_letter
-            )
-          end
+  task :jobs, [:year] => [:environment] do |_t, args|
+    (1..12).to_a.each do |month|
+      ('a'..'z').to_a.each do |first_letter|
+        ('a'..'z').to_a.each do |last_letter|
+          Ok2Explore::ScrapeJob.create(
+            year: args.year,
+            month: month,
+            first_name: first_letter,
+            last_name: last_letter
+          )
         end
       end
     end

--- a/lib/tasks/deaths.rake
+++ b/lib/tasks/deaths.rake
@@ -1,7 +1,5 @@
 require 'uri'
 
-# rubocop:disable Metrics/BlockLength
-
 namespace :scrape do
   desc 'Scrape cases into database for a given county and'
   task :deaths, [:start_year, :end_year] => [:environment] do |_t, args|
@@ -37,5 +35,3 @@ namespace :scrape do
     end
   end
 end
-
-# rubocop:enable Metrics/BlockLength

--- a/spec/models/ok2_explore/death_spec.rb
+++ b/spec/models/ok2_explore/death_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Ok2Explore::Death, type: :model do
   describe 'associations' do
-    it { should belong_to(:county) }
+    it { should belong_to(:county).optional }
   end
 
   describe 'validations' do

--- a/spec/services/importers/ok2_explore/scrape_job_spec.rb
+++ b/spec/services/importers/ok2_explore/scrape_job_spec.rb
@@ -18,7 +18,8 @@ RSpec.describe Importers::Ok2Explore::ScrapeJob do
 
     context 'when too many records retrieved' do
       it 'fans out records and sets as too many records' do
-        allow_any_instance_of(::Ok2explore::Scraper).to receive(:perform).and_raise(::Ok2explore::Errors::TooManyResults)
+        allow_any_instance_of(::Ok2explore::Scraper)
+          .to receive(:perform).and_raise(::Ok2explore::Errors::TooManyResults)
         described_class.perform(scrape_job)
         scrape_job.is_too_many_records = true
         expect(Ok2Explore::ScrapeJob.find_by(last_name: 'ua')).not_to be_nil

--- a/spec/services/importers/ok2_explore/scrape_job_spec.rb
+++ b/spec/services/importers/ok2_explore/scrape_job_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe Importers::Ok2Explore::ScrapeJob do
+  describe '#perform' do
+    before do
+      Rails.application.load_seed
+    end
+    let!(:scrape_job) { create(:ok2_explore_scrape_job, year: 2019, month: 12, first_name: 'd', last_name: 'u') }
+
+    it 'creates death records and updates scrape_job' do
+      VCR.use_cassette 'ok2_explore_job' do
+        described_class.perform(scrape_job)
+        expect(Ok2Explore::Death.count).to be >= 1
+        scrape_job.is_success = true
+        scrape_job.is_too_many_records = false
+      end
+    end
+
+    context 'when too many records retrieved' do
+      it 'fans out records and sets as too many records' do
+        allow_any_instance_of(::Ok2explore::Scraper).to receive(:perform).and_raise(::Ok2explore::Errors::TooManyResults)
+        described_class.perform(scrape_job)
+        scrape_job.is_too_many_records = true
+        expect(Ok2Explore::ScrapeJob.find_by(last_name: 'ua')).not_to be_nil
+        expect(Ok2Explore::ScrapeJob.find_by(last_name: 'uz')).not_to be_nil
+      end
+    end
+  end
+end

--- a/spec/services/importers/ok2_explore/scrape_job_spec.rb
+++ b/spec/services/importers/ok2_explore/scrape_job_spec.rb
@@ -17,9 +17,11 @@ RSpec.describe Importers::Ok2Explore::ScrapeJob do
     end
 
     context 'when too many records retrieved' do
-      it 'fans out records and sets as too many records' do
+      before do
         allow_any_instance_of(::Ok2explore::Scraper)
           .to receive(:perform).and_raise(::Ok2explore::Errors::TooManyResults)
+      end
+      it 'fans out records and sets as too many records' do
         described_class.perform(scrape_job)
         scrape_job.is_too_many_records = true
         expect(Ok2Explore::ScrapeJob.find_by(last_name: 'ua')).not_to be_nil

--- a/spec/services/importers/ok2_explore/scrape_job_spec.rb
+++ b/spec/services/importers/ok2_explore/scrape_job_spec.rb
@@ -5,16 +5,16 @@ RSpec.describe Importers::Ok2Explore::ScrapeJob do
     before do
       Rails.application.load_seed
       scraped_records = [{
-                           'lastName' => 'UNDER',
-                           'firstName' => 'DAVID',
-                           'middleName' => 'J',
-                           'deathDate' => '2019-12-25T00:00:00',
-                           'deathDay' => 25,
-                           'deathMonth' => 12,
-                           'deathYear' => 2019,
-                           'deathCounty' => 'Comanche',
-                           'gender' => 'M'
-                         }]
+        'lastName' => 'UNDER',
+        'firstName' => 'DAVID',
+        'middleName' => 'J',
+        'deathDate' => '2019-12-25T00:00:00',
+        'deathDay' => 25,
+        'deathMonth' => 12,
+        'deathYear' => 2019,
+        'deathCounty' => 'Comanche',
+        'gender' => 'M'
+      }]
       allow_any_instance_of(::Ok2explore::Scraper).to receive(:perform).and_return(scraped_records)
     end
     let!(:scrape_job) { create(:ok2_explore_scrape_job, year: 2019, month: 12, first_name: 'd', last_name: 'u') }

--- a/spec/services/importers/ok2_explore/scrape_job_spec.rb
+++ b/spec/services/importers/ok2_explore/scrape_job_spec.rb
@@ -4,16 +4,26 @@ RSpec.describe Importers::Ok2Explore::ScrapeJob do
   describe '#perform' do
     before do
       Rails.application.load_seed
+      scraped_records = [{
+                           'lastName' => 'UNDER',
+                           'firstName' => 'DAVID',
+                           'middleName' => 'J',
+                           'deathDate' => '2019-12-25T00:00:00',
+                           'deathDay' => 25,
+                           'deathMonth' => 12,
+                           'deathYear' => 2019,
+                           'deathCounty' => 'Comanche',
+                           'gender' => 'M'
+                         }]
+      allow_any_instance_of(::Ok2explore::Scraper).to receive(:perform).and_return(scraped_records)
     end
     let!(:scrape_job) { create(:ok2_explore_scrape_job, year: 2019, month: 12, first_name: 'd', last_name: 'u') }
 
     it 'creates death records and updates scrape_job' do
-      VCR.use_cassette 'ok2_explore_job' do
-        described_class.perform(scrape_job)
-        expect(Ok2Explore::Death.count).to be >= 1
-        scrape_job.is_success = true
-        scrape_job.is_too_many_records = false
-      end
+      described_class.perform(scrape_job)
+      expect(Ok2Explore::Death.count).to be >= 1
+      scrape_job.is_success = true
+      scrape_job.is_too_many_records = false
     end
 
     context 'when too many records retrieved' do

--- a/spec/services/importers/ok2_explore/scrape_pending_jobs_spec.rb
+++ b/spec/services/importers/ok2_explore/scrape_pending_jobs_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe Importers::Ok2Explore::ScrapePendingJobs do
+  describe '#perform' do
+    before do
+      Rails.application.load_seed
+    end
+    let!(:scrape_job) { create(:ok2_explore_scrape_job, year: 2019, month: 12, first_name: 'd', last_name: 'u') }
+    it 'creates death records' do
+      VCR.use_cassette 'ok2_explore_pending_jobs' do
+        described_class.perform(10)
+        expect(Ok2Explore::Death.count).to be >= 1
+      end
+    end
+  end
+end

--- a/spec/services/importers/ok2_explore/scrape_pending_jobs_spec.rb
+++ b/spec/services/importers/ok2_explore/scrape_pending_jobs_spec.rb
@@ -4,13 +4,23 @@ RSpec.describe Importers::Ok2Explore::ScrapePendingJobs do
   describe '#perform' do
     before do
       Rails.application.load_seed
+      scraped_records = [{
+        'lastName' => 'UNDER',
+        'firstName' => 'DAVID',
+        'middleName' => 'J',
+        'deathDate' => '2019-12-25T00:00:00',
+        'deathDay' => 25,
+        'deathMonth' => 12,
+        'deathYear' => 2019,
+        'deathCounty' => 'Comanche',
+        'gender' => 'M'
+      }]
+      allow_any_instance_of(::Ok2explore::Scraper).to receive(:perform).and_return(scraped_records)
     end
     let!(:scrape_job) { create(:ok2_explore_scrape_job, year: 2019, month: 12, first_name: 'd', last_name: 'u') }
     it 'creates death records' do
-      VCR.use_cassette 'ok2_explore_pending_jobs' do
-        described_class.perform(10)
-        expect(Ok2Explore::Death.count).to be >= 1
-      end
+      described_class.perform(10)
+      expect(Ok2Explore::Death.count).to be >= 1
     end
   end
 end


### PR DESCRIPTION
## scrape:death_records  Updates
For scrape:death_records in deaths.rake
- break up into multiple importers
- fan out jobs that hit limit into smaller jobs
- utilize progress bar with progress bar logging
- skip records with no county

## scrape:jobs Updates
For scrape:jobs in deaths.rake
- pass in a year to create scrape jobs, e.g., `bundle exec rake 'scrape:jobs[2019]`